### PR TITLE
Add POST /api/v1/research/target endpoint

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/BaseControllers/ResearchController.cs
+++ b/Source/RIMAPI/RimworldRestApi/BaseControllers/ResearchController.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Threading.Tasks;
 using RIMAPI.Core;
 using RIMAPI.Http;
+using RIMAPI.Models;
 using RIMAPI.Services;
 
 namespace RIMAPI.Controllers
@@ -48,6 +49,15 @@ namespace RIMAPI.Controllers
         public async Task GetResearchSummary(HttpListenerContext context)
         {
             var result = _researchService.GetResearchSummary();
+            await context.SendJsonResponse(result);
+        }
+
+        [Post("/api/v1/research/target")]
+        [EndpointMetadata("Set the current research project by defName")]
+        public async Task SetResearchTarget(HttpListenerContext context)
+        {
+            var name = RequestParser.GetStringParameter(context, "name");
+            var result = _researchService.SetResearchTarget(name);
             await context.SendJsonResponse(result);
         }
     }

--- a/Source/RIMAPI/RimworldRestApi/Helpers/ResearchHelper.cs
+++ b/Source/RIMAPI/RimworldRestApi/Helpers/ResearchHelper.cs
@@ -118,6 +118,16 @@ namespace RIMAPI.Helpers
             }
         }
 
+        public static ResearchProjectDto SetResearchTarget(string projectDefName)
+        {
+            var project = DefDatabase<ResearchProjectDef>.GetNamedSilentFail(projectDefName);
+            if (project == null)
+                return null;
+
+            Find.ResearchManager.SetCurrentProject(project);
+            return ResearchProjectToDto(project);
+        }
+
         public static ResearchSummaryDto GetResearchSummary()
         {
             try

--- a/Source/RIMAPI/RimworldRestApi/Services/Interfaces/IResearchService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Interfaces/IResearchService.cs
@@ -12,5 +12,6 @@ namespace RIMAPI.Services
         ApiResult<ResearchTreeDto> GetResearchTree();
         ApiResult<ResearchProjectDto> GetResearchProjectByName(string name);
         ApiResult<ResearchSummaryDto> GetResearchSummary();
+        ApiResult<ResearchProjectDto> SetResearchTarget(string projectDefName);
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/ResearchService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/ResearchService.cs
@@ -53,5 +53,16 @@ namespace RIMAPI.Services
             var result = ResearchHelper.GetResearchTree();
             return ApiResult<ResearchTreeDto>.Ok(result);
         }
+
+        public ApiResult<ResearchProjectDto> SetResearchTarget(string projectDefName)
+        {
+            var result = ResearchHelper.SetResearchTarget(projectDefName);
+            if (result == null)
+            {
+                return ApiResult<ResearchProjectDto>
+                    .Fail($"Research project not found: {projectDefName}");
+            }
+            return ApiResult<ResearchProjectDto>.Ok(result);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a write endpoint to the `ResearchController` that sets the active research project by `defName`.

- **Endpoint**: `POST /api/v1/research/target?name={defName}`
- **Returns**: `ApiResult<ResearchProjectDto>` with the newly-selected project
- **Error**: Returns failure result if project defName not found

### Changes
- `ResearchHelper.SetResearchTarget()` — calls `Find.ResearchManager.SetCurrentProject()`
- `IResearchService.SetResearchTarget()` — interface contract
- `ResearchService.SetResearchTarget()` — service implementation with null check
- `ResearchController.SetResearchTarget()` — `[Post]` controller action with `[EndpointMetadata]`

### Motivation

We're building [RLE (RimWorld Learning Environment)](https://github.com/AppSprout-dev/RLE), a multi-agent AI benchmark where LLM agents manage a RimWorld colony via RIMAPI. Our `ResearchDirector` agent needs to set research targets programmatically. The existing `ResearchController` has excellent read coverage (progress, tree, summary, project lookup) but no write endpoint.

This endpoint is general-purpose and follows the existing controller/service/helper pattern exactly.

### Usage

```
POST /api/v1/research/target?name=Electricity
```

```json
{
  "Success": true,
  "Data": {
    "Name": "Electricity",
    "Label": "Electricity",
    "Progress": 0,
    "ResearchPoints": 1600,
    "IsFinished": false,
    "CanStartNow": true,
    ...
  }
}
```

### Testing
- Verified the pattern matches existing controllers (query param via `RequestParser.GetStringParameter`)
- Uses `DefDatabase<ResearchProjectDef>.GetNamedSilentFail()` for safe lookup (no exception on missing)
- Returns typed `ApiResult<ResearchProjectDto>.Fail()` on not-found, consistent with `GetResearchProjectByName`