### PR TITLE
Add pawn job assignment and medical endpoints

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/BaseControllers/PawnJobController.cs
+++ b/Source/RIMAPI/RimworldRestApi/BaseControllers/PawnJobController.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Threading.Tasks;
+using RIMAPI.Core;
+using RIMAPI.Http;
+using RIMAPI.Models;
+using RIMAPI.Services;
+
+namespace RIMAPI.Controllers
+{
+    public class PawnJobController
+    {
+        private readonly IPawnJobService _pawnJobService;
+
+        public PawnJobController(IPawnJobService pawnJobService)
+        {
+            _pawnJobService = pawnJobService;
+        }
+
+        [Post("/api/v1/pawn/job")]
+        [EndpointMetadata("Assign a job to a pawn by JobDef name, with optional target")]
+        public async Task AssignJob(HttpListenerContext context)
+        {
+            var body = await context.Request.ReadBodyAsync<PawnJobRequestDto>();
+            var result = _pawnJobService.AssignJob(body);
+            await context.SendJsonResponse(result);
+        }
+
+        [Post("/api/v1/pawn/medical/tend")]
+        [EndpointMetadata("Assign a doctor to tend a patient")]
+        public async Task AssignTendJob(HttpListenerContext context)
+        {
+            var body = await context.Request.ReadBodyAsync<MedicalTendRequestDto>();
+            var result = _pawnJobService.AssignTendJob(body);
+            await context.SendJsonResponse(result);
+        }
+
+        [Post("/api/v1/pawn/medical/bed-rest")]
+        [EndpointMetadata("Assign a pawn to bed rest, optionally specifying a bed")]
+        public async Task AssignBedRest(HttpListenerContext context)
+        {
+            var body = await context.Request.ReadBodyAsync<MedicalBedRestRequestDto>();
+            var result = _pawnJobService.AssignBedRest(body);
+            await context.SendJsonResponse(result);
+        }
+    }
+}

--- a/Source/RIMAPI/RimworldRestApi/Helpers/PawnHelper.cs
+++ b/Source/RIMAPI/RimworldRestApi/Helpers/PawnHelper.cs
@@ -5,6 +5,7 @@ using RIMAPI.Models;
 using RimWorld;
 using UnityEngine;
 using Verse;
+using Verse.AI;
 
 namespace RIMAPI.Helpers
 {
@@ -49,6 +50,28 @@ namespace RIMAPI.Helpers
                     Z = pawn.Position.z,
                 },
             };
+        }
+
+        public static bool AssignJob(Pawn pawn, JobDef jobDef, LocalTargetInfo target)
+        {
+            Job job = JobMaker.MakeJob(jobDef, target);
+            return pawn.jobs.TryTakeOrderedJob(job);
+        }
+
+        public static bool AssignTendJob(Pawn doctor, Pawn patient)
+        {
+            Job job = JobMaker.MakeJob(JobDefOf.TendPatient, patient);
+            return doctor.jobs.TryTakeOrderedJob(job);
+        }
+
+        public static bool AssignBedRest(Pawn patient, Building_Bed bed)
+        {
+            if (bed != null)
+            {
+                patient.ownership.ClaimBedIfNonMedical(bed);
+            }
+            Job job = JobMaker.MakeJob(JobDefOf.LayDown, patient.ownership.OwnedBed ?? bed);
+            return patient.jobs.TryTakeOrderedJob(job);
         }
 
         public static PawnInventoryDto GetPawnInventory(Pawn pawn)

--- a/Source/RIMAPI/RimworldRestApi/Models/Pawns/ColonistDto.cs
+++ b/Source/RIMAPI/RimworldRestApi/Models/Pawns/ColonistDto.cs
@@ -238,4 +238,24 @@ namespace RIMAPI.Models
         public bool AllowedHitPointsConfigurable { get; set; }
         public bool AllowedQualitiesConfigurable { get; set; }
     }
+
+    public class PawnJobRequestDto
+    {
+        public int PawnId { get; set; }
+        public string JobDef { get; set; }
+        public int? TargetThingId { get; set; }
+        public PositionDto TargetPosition { get; set; }
+    }
+
+    public class MedicalTendRequestDto
+    {
+        public int PatientPawnId { get; set; }
+        public int? DoctorPawnId { get; set; }
+    }
+
+    public class MedicalBedRestRequestDto
+    {
+        public int PatientPawnId { get; set; }
+        public int? BedBuildingId { get; set; }
+    }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/Interfaces/IPawnJobService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Interfaces/IPawnJobService.cs
@@ -1,0 +1,12 @@
+using RIMAPI.Core;
+using RIMAPI.Models;
+
+namespace RIMAPI.Services
+{
+    public interface IPawnJobService
+    {
+        ApiResult AssignJob(PawnJobRequestDto request);
+        ApiResult AssignTendJob(MedicalTendRequestDto request);
+        ApiResult AssignBedRest(MedicalBedRestRequestDto request);
+    }
+}

--- a/Source/RIMAPI/RimworldRestApi/Services/PawnJobService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/PawnJobService.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Linq;
+using RIMAPI.Core;
+using RIMAPI.Helpers;
+using RIMAPI.Models;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace RIMAPI.Services
+{
+    public class PawnJobService : IPawnJobService
+    {
+        public PawnJobService() { }
+
+        public ApiResult AssignJob(PawnJobRequestDto request)
+        {
+            try
+            {
+                Pawn pawn = PawnHelper.FindPawnById(request.PawnId);
+                if (pawn == null)
+                {
+                    return ApiResult.Fail($"Pawn not found: {request.PawnId}");
+                }
+
+                JobDef jobDef = DefDatabase<JobDef>.GetNamedSilentFail(request.JobDef);
+                if (jobDef == null)
+                {
+                    return ApiResult.Fail($"JobDef not found: {request.JobDef}");
+                }
+
+                LocalTargetInfo target = LocalTargetInfo.Invalid;
+
+                if (request.TargetThingId.HasValue)
+                {
+                    Thing thing = null;
+                    foreach (Map map in Find.Maps)
+                    {
+                        thing = map.listerThings.AllThings
+                            .FirstOrDefault(t => t.thingIDNumber == request.TargetThingId.Value);
+                        if (thing != null) break;
+                    }
+                    if (thing == null)
+                    {
+                        return ApiResult.Fail($"Target thing not found: {request.TargetThingId}");
+                    }
+                    target = thing;
+                }
+                else if (request.TargetPosition != null)
+                {
+                    target = new IntVec3(
+                        request.TargetPosition.X, 0, request.TargetPosition.Z);
+                }
+
+                bool success = PawnHelper.AssignJob(pawn, jobDef, target);
+                if (!success)
+                {
+                    return ApiResult.Fail($"Pawn {request.PawnId} could not accept job {request.JobDef}");
+                }
+                return ApiResult.Ok();
+            }
+            catch (Exception ex)
+            {
+                return ApiResult.Fail(ex.Message);
+            }
+        }
+
+        public ApiResult AssignTendJob(MedicalTendRequestDto request)
+        {
+            try
+            {
+                Pawn patient = PawnHelper.FindPawnById(request.PatientPawnId);
+                if (patient == null)
+                {
+                    return ApiResult.Fail($"Patient pawn not found: {request.PatientPawnId}");
+                }
+
+                Pawn doctor;
+                if (request.DoctorPawnId.HasValue)
+                {
+                    doctor = PawnHelper.FindPawnById(request.DoctorPawnId.Value);
+                    if (doctor == null)
+                    {
+                        return ApiResult.Fail($"Doctor pawn not found: {request.DoctorPawnId}");
+                    }
+                }
+                else
+                {
+                    // Find the best available doctor on the same map
+                    doctor = patient.Map?.mapPawns.FreeColonists
+                        .Where(p => p != patient && !p.Downed && !p.Dead)
+                        .OrderByDescending(p => p.skills?.GetSkill(SkillDefOf.Medicine)?.Level ?? 0)
+                        .FirstOrDefault();
+
+                    if (doctor == null)
+                    {
+                        return ApiResult.Fail("No available doctor found on the map");
+                    }
+                }
+
+                bool success = PawnHelper.AssignTendJob(doctor, patient);
+                if (!success)
+                {
+                    return ApiResult.Fail("Doctor could not accept tend job");
+                }
+                return ApiResult.Ok();
+            }
+            catch (Exception ex)
+            {
+                return ApiResult.Fail(ex.Message);
+            }
+        }
+
+        public ApiResult AssignBedRest(MedicalBedRestRequestDto request)
+        {
+            try
+            {
+                Pawn patient = PawnHelper.FindPawnById(request.PatientPawnId);
+                if (patient == null)
+                {
+                    return ApiResult.Fail($"Patient pawn not found: {request.PatientPawnId}");
+                }
+
+                Building_Bed bed = null;
+                if (request.BedBuildingId.HasValue)
+                {
+                    Building building = BuildingHelper.FindBuildingByID(request.BedBuildingId.Value);
+                    bed = building as Building_Bed;
+                    if (bed == null)
+                    {
+                        return ApiResult.Fail($"Bed not found: {request.BedBuildingId}");
+                    }
+                }
+
+                bool success = PawnHelper.AssignBedRest(patient, bed);
+                if (!success)
+                {
+                    return ApiResult.Fail("Patient could not be assigned to bed rest");
+                }
+                return ApiResult.Ok();
+            }
+            catch (Exception ex)
+            {
+                return ApiResult.Fail(ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three new pawn-related write endpoints, bundled as a single pawn category PR. These cover generic job assignment and medical care management.

### 1. Generic Job Assignment — `POST /api/v1/pawn/job`

Assign any job to a pawn by `JobDef` name, with optional target (thing or position).

**Request body:**
```json
{
  "PawnId": 123,
  "JobDef": "Haul",
  "TargetThingId": 456
}
```
Or with a position target:
```json
{
  "PawnId": 123,
  "JobDef": "Goto",
  "TargetPosition": {"X": 50, "Z": 30}
}
```

Uses `DefDatabase<JobDef>.GetNamedSilentFail()` for safe lookup. Supports any vanilla or modded `JobDef` (Haul, Hunt, Mine, Tend_Plant, Goto, etc.).

### 2. Medical Tend — `POST /api/v1/pawn/medical/tend`

Assign a doctor to tend a patient's injuries/illnesses.

**Request body:**
```json
{
  "PatientPawnId": 123,
  "DoctorPawnId": 456
}
```

If `DoctorPawnId` is omitted, auto-selects the best available doctor on the same map (highest Medicine skill, not downed/dead, not the patient).

### 3. Bed Rest — `POST /api/v1/pawn/medical/bed-rest`

Assign a pawn to bed rest, optionally specifying which bed.

**Request body:**
```json
{
  "PatientPawnId": 123,
  "BedBuildingId": 789
}
```

If `BedBuildingId` is omitted, uses the pawn's currently owned bed.

### Changes

- `PawnHelper.cs` — 3 new static methods: `AssignJob()`, `AssignTendJob()`, `AssignBedRest()`
- New `IPawnJobService` interface + `PawnJobService` implementation (auto-discovered by DI)
- New `PawnJobController` with 3 `[Post]` endpoints
- 3 request DTOs added to `ColonistDto.cs`: `PawnJobRequestDto`, `MedicalTendRequestDto`, `MedicalBedRestRequestDto`

### Motivation

Same project as PRs #52 and #53 — [RLE (RimWorld Learning Environment)](https://github.com/AppSprout-dev/RLE). Our `MedicalOfficer` agent needs to assign bed rest and tend jobs, and all agents need generic job assignment for actions like hauling and hunting.

This completes our set of upstream contributions — together with #52 (research target) and #53 (power toggle + growing zones), these PRs cover all the write endpoints we need.