### PR TITLE
Fix growing zone 500 error when all cells are occupied

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/Helpers/FarmHelper.cs
+++ b/Source/RIMAPI/RimworldRestApi/Helpers/FarmHelper.cs
@@ -187,6 +187,14 @@ namespace RIMAPI.Helpers
                     zone.AddCell(cell);
                 }
             }
+
+            // No valid cells added — remove the empty zone and report failure
+            if (zone.CellCount == 0)
+            {
+                zone.Delete();
+                return null;
+            }
+
             zone.SetPlantDefToGrow(plantDef);
             return GetGrowingZoneById(map, zone.ID);
         }


### PR DESCRIPTION
## Bug

`POST /api/v1/map/zone/growing` returns HTTP 500 with `"Value cannot be null. Parameter name: source"` when all requested cells are already occupied by existing zones.

## Root Cause

`FarmHelper.CreateGrowingZone()` registers a new zone via `RegisterZone()`, then iterates cells — but skips any that are already occupied. If **all** cells are occupied, the zone ends up with 0 cells. Then `GetGrowingZoneById()` is called on this empty zone, where `zone.ContainsCell()` inside a LINQ chain triggers a `NullReferenceException` because the zone's internal cell data is in an invalid state.

## Fix

Check `zone.CellCount` after adding cells. If 0, call `zone.Delete()` to clean up and return `null` — which the service layer already handles as `ApiResult.Fail("Invalid plant definition: ...")`.

## Reproduction

```bash
# Create a zone at (120,130)-(125,135)
curl -X POST -H "Content-Type: application/json" \
  -d '{"map_id":0,"plant_def":"Plant_Potato","point_a":{"x":120,"y":0,"z":130},"point_b":{"x":125,"y":0,"z":135}}' \
  http://localhost:8765/api/v1/map/zone/growing
# → 200 OK

# Create overlapping zone at same coordinates
curl -X POST -H "Content-Type: application/json" \
  -d '{"map_id":0,"plant_def":"Plant_Rice","point_a":{"x":120,"y":0,"z":130},"point_b":{"x":125,"y":0,"z":135}}' \
  http://localhost:8765/api/v1/map/zone/growing
# → 500 "Value cannot be null: source" (before fix)
# → 400 "Invalid plant definition: Plant_Rice" (after fix — could improve error message)
```

Found during live RLE benchmark testing — our AI agents sometimes request growing zones on already-occupied cells.