### PR TITLE
Fix NullReferenceException in bulk work priorities endpoint

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/Models/Pawns/ColonistDto.cs
+++ b/Source/RIMAPI/RimworldRestApi/Models/Pawns/ColonistDto.cs
@@ -212,7 +212,8 @@ namespace RIMAPI.Models
 
     public class ColonistsWorkPrioritiesRequestDto
     {
-        public List<WorkPriorityRequestDto> Priorities { get; set; }
+        [JsonProperty("priorities")]
+        public List<WorkPriorityRequestDto> Priorities { get; set; } = new List<WorkPriorityRequestDto>();
     }
 
     public class TimeAssignmentDto

--- a/Source/RIMAPI/RimworldRestApi/Services/ColonistService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/ColonistService.cs
@@ -252,24 +252,37 @@ namespace RIMAPI.Services
         {
             try
             {
+                if (body?.Priorities == null)
+                {
+                    return ApiResult.Fail("Invalid payload: 'priorities' array is missing or null.");
+                }
+
+                if (body.Priorities.Count == 0)
+                {
+                    return ApiResult.Ok();
+                }
+
                 var warnings = new List<string>();
                 foreach (var colonistPriorityUpdate in body.Priorities)
                 {
                     var result = SetColonistWorkPriority(colonistPriorityUpdate);
                     if (result.Success == false)
                     {
-                        warnings.Add(result.Errors.ToString());
+                        warnings.AddRange(result.Errors);
                     }
                 }
 
                 if (warnings.Count > 0)
                 {
+                    string combinedWarnings = string.Join("; ", warnings);
+
                     if (warnings.Count == body.Priorities.Count)
                     {
-                        return ApiResult.Fail(warnings.ToString());
+                        return ApiResult.Fail(combinedWarnings);
                     }
                     return ApiResult.Partial(warnings);
                 }
+
                 return ApiResult.Ok();
             }
             catch (Exception ex)


### PR DESCRIPTION
- Added defensive null checks for missing or empty 'priorities' payloads in ColonistService
- Added [JsonProperty] attribute to ColonistsWorkPrioritiesRequestDto to enforce strict mapping
- Added a new ApiResult.Fail() overload to properly handle and return collections of errors
- Prevented API from returning internal class names (List`1) when partial updates fail
- Resolves 500 Internal Server Error when processing unmapped JSON keys