### PR TITLE
Add POST /api/v1/things/set-forbidden endpoint

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/BaseControllers/ThingsController.cs
+++ b/Source/RIMAPI/RimworldRestApi/BaseControllers/ThingsController.cs
@@ -75,5 +75,14 @@ namespace RIMAPI.Controllers
             var result = _thingsService.GetItemSources(itemDef);
             await context.SendJsonResponse(result);
         }
+
+        [Post("/api/v1/things/set-forbidden")]
+        [EndpointMetadata("Set forbidden status on one or more things")]
+        public async Task SetForbidden(HttpListenerContext context)
+        {
+            var body = await context.Request.ReadBodyAsync<SetForbiddenRequestDto>();
+            var result = _thingsService.SetForbidden(body);
+            await context.SendJsonResponse(result);
+        }
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Models/Common/ThingDto.cs
+++ b/Source/RIMAPI/RimworldRestApi/Models/Common/ThingDto.cs
@@ -60,6 +60,13 @@ namespace RIMAPI.Models
         }
     }
 
+    public class SetForbiddenRequestDto
+    {
+        public List<int> ThingIds { get; set; }
+        public int MapId { get; set; }
+        public bool Forbidden { get; set; }
+    }
+
     public class ThingSourcesDto
     {
         public string DefName { get; set; }

--- a/Source/RIMAPI/RimworldRestApi/Services/Interfaces/IThingsService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Interfaces/IThingsService.cs
@@ -9,5 +9,6 @@ namespace RIMAPI.Services
     {
         ApiResult<ItemRecipesDto> GetItemRecipes(string defName);
         ApiResult<ThingSourcesDto> GetItemSources(string defName);
+        ApiResult SetForbidden(SetForbiddenRequestDto request);
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/ThingsService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/ThingsService.cs
@@ -224,5 +224,48 @@ namespace RIMAPI.Services
                 return ApiResult<ThingSourcesDto>.Fail(ex.Message);
             }
         }
+
+        public ApiResult SetForbidden(SetForbiddenRequestDto request)
+        {
+            try
+            {
+                if (request.ThingIds == null || request.ThingIds.Count == 0)
+                    return ApiResult.Fail("thing_ids list is required and must not be empty");
+
+                var map = Find.Maps.FirstOrDefault(m => m.uniqueID == request.MapId);
+                if (map == null)
+                    return ApiResult.Fail($"Map {request.MapId} not found");
+
+                var warnings = new List<string>();
+                int updated = 0;
+
+                foreach (var thingId in request.ThingIds)
+                {
+                    var thing = map.listerThings.AllThings
+                        .FirstOrDefault(t => t.thingIDNumber == thingId);
+
+                    if (thing == null)
+                    {
+                        warnings.Add($"Thing {thingId} not found");
+                        continue;
+                    }
+
+                    thing.SetForbidden(request.Forbidden, false);
+                    updated++;
+                }
+
+                if (warnings.Count > 0 && updated == 0)
+                    return ApiResult.Fail($"No things were updated: {string.Join(", ", warnings)}");
+
+                if (warnings.Count > 0)
+                    return ApiResult.Partial(warnings);
+
+                return ApiResult.Ok();
+            }
+            catch (Exception ex)
+            {
+                return ApiResult.Fail($"Failed to set forbidden: {ex.Message}");
+            }
+        }
     }
 }

--- a/docs/_api_macroses/controllers/ThingsController.yml
+++ b/docs/_api_macroses/controllers/ThingsController.yml
@@ -321,3 +321,47 @@ desc: |-
         "timestamp": "2025-12-10T19:53:16.733319Z"
     }
     ```
+/api/v1/things/set-forbidden:
+  desc: Toggle the forbidden status on one or more things by ID. Useful for unforbidding starting items in a new colony or managing item access for colonists.
+  curl: |-
+    **Example:**
+    ```bash
+    curl --request POST \
+    --url http://localhost:8765/api/v1/things/set-forbidden \
+    --header 'content-type: application/json' \
+    --data '{
+        "thing_ids": [12345, 12346, 12347],
+        "map_id": 0,
+        "forbidden": false
+    }'
+    ```
+  request: |-
+    **Request:**
+    ```json
+    {
+        "thing_ids": [12345, 12346, 12347],
+        "map_id": 0,
+        "forbidden": false
+    }
+    ```
+  response: |-
+    **Response (all updated):**
+    ```json
+    {
+        "success": true,
+        "errors": [],
+        "warnings": [],
+        "timestamp": "2026-03-31T03:45:51.148Z"
+    }
+    ```
+
+    **Response (partial — some things not found):**
+    ```json
+    {
+        "success": true,
+        "errors": [],
+        "warnings": ["Thing 99999 not found"],
+        "timestamp": "2026-03-31T03:45:51.148Z"
+    }
+    ```
+  method: POST

--- a/tests/bruno_api_collection/Things/Set Forbidden.yml
+++ b/tests/bruno_api_collection/Things/Set Forbidden.yml
@@ -1,0 +1,23 @@
+info:
+  name: Set Forbidden
+  type: http
+  seq: 1
+
+http:
+  method: POST
+  url: "{{baseURL}}/api/v1/things/set-forbidden"
+  body:
+    type: json
+    data: |-
+      {
+        "thing_ids": [12345, 12346],
+        "map_id": 0,
+        "forbidden": false
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5


### PR DESCRIPTION
## Summary

Adds an endpoint to toggle the forbidden status on map things. This is the write counterpart to the `is_forbidden` field already returned by `GET /api/v1/map/things`.

## Motivation

When RimWorld starts a Crashlanded scenario, all dropped items (survival meals, medicine, steel, etc.) spawn as `is_forbidden = true`. Colonists won't interact with forbidden items — they'll starve next to survival meals. AI agents and external tools need a way to unforbid items programmatically.

The existing `POST /api/v1/map/destroy/forbidden` destroys forbidden items entirely — this endpoint provides the non-destructive alternative of toggling the flag.

## Endpoint

```
POST /api/v1/things/set-forbidden
```

**Request body:**
```json
{
  "thing_ids": [12345, 12346, 12347],
  "map_id": 0,
  "forbidden": false
}
```

**Responses:**
- `200` — all things updated successfully
- `200` with warnings — some things updated, others not found (partial success)
- `500` — no things found / other error

## Implementation

- **DTO**: `SetForbiddenRequestDto` with `ThingIds` (list), `MapId`, `Forbidden`
- **Service**: `ThingsService.SetForbidden()` — iterates thing IDs, looks up on map, calls `thing.SetForbidden(bool, false)`
- **Controller**: `ThingController.SetForbidden()` — reads body, delegates to service

Uses RimWorld's built-in `Thing.SetForbidden()` extension method from `ForbidUtility`. The `warnOnFail` parameter is set to `false` to avoid spamming the game log.

Bulk design supports unforbidding all starting items in a single request (typical Crashlanded scenario has 10-15 items).

## Testing

Built and verified against RimWorld 1.6.4633. 4 files changed, 60 insertions.