### PR TITLE
docs: restructure API reference

### DIFF
--- a/docs/api/_api_template.md
+++ b/docs/api/_api_template.md
@@ -1,0 +1,62 @@
+{% macro render_controllers(controller_names) %}
+{% set lang = config.theme.language if config.theme.language in api_data else 'en' %}
+{% set current_api = api_data.get(lang, api_data['en']) %}
+
+{% for name in controller_names %}
+{% set controller = current_api.controllers.get(name) %}
+{% if controller %}
+
+{{ controller.title | default('### ' ~ name) }}
+
+{{ controller.desc | default('') }}
+
+{% for path, data in controller.items() %}
+{% if path.startswith('/') %}
+---
+
+<h4 id="{{ path | replace('/', '') | replace('-', '') | replace('{', '') | replace('}', '') | lower }}">
+<div class="doc-api-container">
+<div class="doc-api-header">
+<div class="doc-api-method doc-api-method-{{ data.method | default('GET') | lower }}">{{ data.method | default('GET') | upper }}</div>
+<div class="doc-api-endpoint">
+<code>
+```text
+{{ path }}
+```
+</code>
+<a class="headerlink" href="#{{ path | replace('/', '') | replace('-', '') | replace('{', '') | replace('}', '') | lower }}" title="Permanent link">¶</a>
+</div>
+</div>
+</div>
+</h4>
+
+{% if data.tags %}
+<div class="doc-api-tags" style="margin-bottom: 15px; display: flex; gap: 8px; flex-wrap: wrap;">
+{% for tag in data.tags %}
+<span class="doc-tag">{{ tag }}</span>
+{% endfor %}
+</div>
+{% endif %}
+
+{{ data.desc | default('') }}
+
+{{ data.curl | default('') }}
+
+{{ data.request | default('') }}
+
+{{ data.response | default('') }}
+
+{% if data.github_link %}
+<div class="doc-github-container">
+<a href="{{ data.github_link }}" class="doc-github-link">
+{{ data.github_name | default('View Source') }}
+</a>
+</div>
+{% endif %}
+
+{% endif %}
+{% endfor %}
+
+{% endif %}
+{% endfor %}
+{% endmacro %}

--- a/docs/api/all.md
+++ b/docs/api/all.md
@@ -1,0 +1,7 @@
+# 📚 Complete API Reference (All Endpoints)
+
+This page contains the complete, unabridged list of all RIMAPI endpoints.
+
+{% from 'api/_api_template.md' import render_controllers with context %}
+{% set lang = config.theme.language if config.theme.language in api_data else 'en' %}
+{{ render_controllers(api_data.get(lang, api_data['en']).controllers.keys()) }}

--- a/docs/api/game.md
+++ b/docs/api/game.md
@@ -1,0 +1,11 @@
+# ⚙️ Game State & Mechanics API
+
+This section handles the core game lifecycle (save/load/pause), triggering random events, managing factions, and research.
+
+{% from 'api/_api_template.md' import render_controllers with context %}
+{{ render_controllers([
+    'GameController',
+    'GameEventsController',
+    'FactionController',
+    'ResearchController'
+]) }}

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,34 @@
+{% set lang = config.theme.language if config.theme.language in api_data else 'en' %}
+{% set current_api = api_data.get(lang, api_data['en']) %}
+
+{# --- Dynamically count endpoints --- #}
+{% set ns = namespace(endpoint_count=0) %}
+{% for controller_name, controller in current_api.controllers.items() %}
+    {% for path in controller.keys() %}
+        {% if path.startswith('/') %}
+            {% set ns.endpoint_count = ns.endpoint_count + 1 %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+# 📚 API Reference Overview
+
+**Version**: {{ current_api.meta.version | default('1.8.3') }}  
+**Endpoints total count**: {{ ns.endpoint_count }}
+
+!!! warning "Warning"
+    Please read our [API Conventions](../developer_guide/api_conventions.md) page to understand our `snake_case` JSON requirements and header rules before using these endpoints.
+
+Welcome to the RIMAPI Reference. Choose a category below to view the available endpoints:
+
+* [**Map & Environment**](map.md) - Weather, zones, terrain, and buildings.
+* [**Pawns & AI**](pawns.md) - Pawn spawning, jobs, medical, editing, and Lord behavior.
+* [**Items & Economy**](things.md) - Physical items, inventories, trading, and player designations.
+* [**Game State & Mechanics**](game.md) - Save/load, random events, factions, and research.
+* [**UI & Camera**](ui.md) - Viewports, windows, images, and visual overlays.
+* [**System & Developer Tools**](system.md) - Cache management, API discovery, and general system diagnostics.
+
+---
+
+### 🤖 LLMs & Power Users
+If you are using an AI coding assistant or simply prefer to search through a single, monolithic document, you can view the [**Complete API Reference (All Endpoints)**](all.md) here.

--- a/docs/api/llms-compact.md
+++ b/docs/api/llms-compact.md
@@ -1,0 +1,13 @@
+# RIMAPI Compact Endpoint Index
+*This file is optimized for LLM context windows and RAG ingestion.*
+
+{# FORCE ENGLISH: Bypasses the i18n overwrite loop and fixes Windows encoding bugs #}
+{% set current_api = api_data['en'] %}
+
+{% for controller_name, controller in current_api.controllers.items() %}
+{% for path, data in controller.items() %}
+{% if path.startswith('/') %}
+{{ data.method | default('GET') | upper }} {{ path }} - {{ data.desc | striptags | replace('\n', ' ') | truncate(150) }}
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/docs/api/map.md
+++ b/docs/api/map.md
@@ -1,0 +1,11 @@
+# 🌍 Map & Environment API
+
+This section covers interacting with the physical game world, weather, buildings, and zones.
+
+{% from 'api/_api_template.md' import render_controllers with context %}
+{{ render_controllers([
+    'MapController', 
+    'GlobalMapController',
+    'BuilderController',
+    'BillController'
+]) }}

--- a/docs/api/pawns.md
+++ b/docs/api/pawns.md
@@ -1,0 +1,13 @@
+# 🧠 Pawns & AI API
+
+This section covers reading, spawning, editing, and controlling pawns, as well as managing group AI behavior (Lords).
+
+{% from 'api/_api_template.md' import render_controllers with context %}
+{{ render_controllers([
+    'PawnController',
+    'PawnInfoController',
+    'PawnEditController',
+    'PawnJobController',
+    'PawnSpawnController',
+    'LordController'
+]) }}

--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -1,0 +1,11 @@
+# 🛠️ System & Developer Tools API
+
+This section contains utility endpoints for developers, including cache management, API discovery, and general system diagnostics.
+
+{% from 'api/_api_template.md' import render_controllers with context %}
+{{ render_controllers([
+    'DevToolsController',
+    'ServerCacheController',
+    'DocumentationController',
+    'General'
+]) }}

--- a/docs/api/things.md
+++ b/docs/api/things.md
@@ -1,0 +1,10 @@
+# 📦 Items & Economy API
+
+This section covers spawning physical items, managing inventories, player designations, and trading with factions.
+
+{% from 'api/_api_template.md' import render_controllers with context %}
+{{ render_controllers([
+    'ThingsController',
+    'TradeController',
+    'OrderController'
+]) }}

--- a/docs/api/ui.md
+++ b/docs/api/ui.md
@@ -1,0 +1,11 @@
+# 🖥️ UI & Camera API
+
+This section provides endpoints for manipulating the in-game camera, opening game windows, and rendering visual overlays or images.
+
+{% from 'api/_api_template.md' import render_controllers with context %}
+{{ render_controllers([
+    'CameraController',
+    'WindowController',
+    'OverlayController',
+    'ImagesController'
+]) }}

--- a/docs/capabilities/capabilities.md
+++ b/docs/capabilities/capabilities.md
@@ -1,0 +1,79 @@
+# 📊 RIMAPI Capabilities Matrix
+
+Welcome to the RIMAPI feature roadmap! This matrix provides a high-level overview of which RimWorld game mechanics are currently accessible via the REST API. 
+
+Use this page to quickly discover what you can build, check our current development progress across the DLCs, and navigate directly to the relevant API endpoints.
+
+---
+
+## 🏕️ Base Game Core (~15% Covered)
+*The fundamental building blocks of colony survival, including map management, pawn jobs, health, architecture, work bills and etc.*
+
+??? abstract "View Core Game Capabilities"
+    **🌍 Map & Environment**
+    Interact with the physical world, weather, and terrain.
+    
+    * [Manage Map Zones (Growing, Stockpiles)](../api/map.md)
+    * [Change Weather & Time](../api/map.md)
+    * [Spawn Drop Pods & Items](../api/map.md)
+    * [Read Terrain & Fog of War Grids](../api/map.md)
+
+    **🧠 Pawns & AI**
+    Control your colonists, their health, and their daily tasks.
+    
+    * [Edit Pawn Skills, Traits, & Passions](../api/pawns.md)
+    * [Force Jobs & Interrupt Current Actions](../api/pawns.md)
+    * [Manage Medical Needs & Bed Rest](../api/pawns.md)
+    * [Spawn New Pawns & Animals](../api/pawns.md)
+
+    **🏭 Buildings & Production**
+    Control the colony's infrastructure and manufacturing.
+    
+    * [Toggle Power Grids & Read Batteries](../api/map.md)
+    * [Queue, Reorder, and Edit Production Bills](../api/map.md)
+    * [Query Available Work Table Recipes](../api/map.md)
+
+    **📦 Items & Economy**
+    Manage physical items, inventories, and player designations.
+    
+    * [Spawn and Manage Physical Things](../api/things.md)
+    * [Manage Player Orders (Mine, Haul, Cut, etc.)](../api/things.md)
+    * [Trade with Factions](../api/things.md)
+
+    **⚙️ Game State & UI**
+    Control the game engine itself.
+    
+    * [Read Colony Wealth & Statistics](../api/game.md)
+    * [Control Game Speed & Pausing](../api/game.md)
+    * [Trigger Main Menu & App Shutdown](../api/game.md)
+    * [Move & Zoom the In-Game Camera](../api/ui.md)
+
+    **🛠️ System & Developer Tools**
+    Utility endpoints for tooling, caching, and discovery.
+    
+    * [List all REST Endpoints (Discovery)](../api/system.md)
+    * [Manage Server Cache](../api/system.md)
+
+---
+
+## 👁️ Ideology DLC (0% Covered)
+*Control the belief systems, moral guides, and rituals of your colony.*
+
+---
+
+## 🌑 Anomaly DLC (0% Covered)
+*Manage containment facilities, dark research, and entity attacks.*
+
+---
+
+## 👑 Royalty DLC (0% Covered)
+*Interact with the fallen empire, royal titles, and psychic powers.*
+
+---
+
+## 🧬 Biotech DLC (0% Covered)
+*Control mechanitors, xenogenetics, and pollution management.*
+
+---
+
+*Don't see a feature you need? [Open an issue on our GitHub](#) to request a new endpoint!*

--- a/docs/contributors_guide/release_flow.md
+++ b/docs/contributors_guide/release_flow.md
@@ -18,7 +18,21 @@ Before bumping the version, finalize the `CHANGELOG.md`.
 2. Change the `[Unreleased]` header to the new version number and today's date (e.g., `## v1.8.3 - 2026-03-28`).
 3. Ensure all significant changes (Features, Fixes, Breaking Changes) are accurately categorized.
 
-## 2. Run the Version Bump Script
+## 2. Format and Validate API Documentation
+Before finalizing the release, ensure all YAML documentation is properly formatted, HTTP methods are synced, and no endpoints are missing or undocumented. Run the following documentation scripts from the root directory:
+
+```bash
+echo "🧹 Formatting YAML files..."
+python scripts/docs/mkdocs_format_yaml.py
+
+echo "🔧 Auto-fixing HTTP methods..."
+python scripts/docs/mkdocs_fix_yaml_methods.py
+
+echo "🔍 Running final validation check..."
+python scripts/docs/mkdocs_check_api.py
+```
+
+## 3. Run the Version Bump Script
 RimAPI uses a Python script to enforce a "Single Source of Truth" for versioning. You do not need to manually edit XML or C# files.
 
 From the root directory of the repository, run the bump script with your new version number:
@@ -36,7 +50,15 @@ What this script does automatically:
 - Updates the documentation metadata in docs/_api_macroses/controllers/_meta.yml
 - Stages all modified files in Git (git add -u)
 
-## 3. Commit and Tag
+## 4. Build the Mod (Multi-Version Support)
+
+!!! warning "Important: Build for 1.5 and 1.6"
+
+    RIMAPI currently supports both RimWorld 1.5 and 1.6. You MUST compile the binaries for both engine versions before packaging the final release folder or uploading to Steam Workshop.
+
+Ensure your build pipeline or IDE targets both versions so that the respective 1.5/Assemblies and 1.6/Assemblies folders are correctly populated.
+
+## 5. Commit and Tag
 
 Once the script finishes and the files are staged, commit the release and create a Git tag. We follow Conventional Commits for our release history.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ description: RIMAPI is a powerful mod that adds a REST API server to RimWorld.
 ![RIMAPI Logo](https://raw.githubusercontent.com/IlyaChichkov/RIMAPI/8cdebce963f69c2aeeb50676ab4b994309a1835b/About/preview.png)
 
 [Getting Started](quick_start.md){ .md-button .md-button--primary }
+[Capabilities Matrix](capabilities/capabilities.md){ .md-button }
 [Contribute](contributors_guide/contribute.md){ .md-button }
 
 ## Overview
@@ -24,5 +25,6 @@ RIMAPI is a powerful mod that adds a REST API server to RimWorld, allowing you t
 
 ### Next Steps
 
-- [API Documentation](https://ilyachichkov.github.io/RIMAPI/api.html)
-- [LLM Format](https://ilyachichkov.github.io/RIMAPI/llms-full.txt)
+- [API Reference Overview](api/index.md)
+- [API Conventions](developer_guide/api_conventions.md)
+- [LLM Format (llms.txt)](llms-full.txt)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,17 @@ extra_css:
 nav:
   - Home: index.md
   - Quick Start: quick_start.md
-  - API Reference: api.md
+  - API Reference: 
+      - Overview: api/index.md
+      - Map & Environment: api/map.md
+      - Pawns & AI: api/pawns.md
+      - Items & Economy: api/things.md
+      - Game State & Mechanics: api/game.md
+      - UI & Camera: api/ui.md
+      - System & Dev Tools: api/system.md
+      - Complete List: api/all.md
+  - Capabilities:
+    - Overview: capabilities/capabilities.md
   - Developers:
     - API Convension: developer_guide/api_conventions.md
     - Create extension: developer_guide/creating_extensions.md
@@ -91,12 +101,12 @@ plugins:
       full_output: llms-full.txt
       sections:
         API documentation:
-        - index.md
-        - api.md
+          - index.md
+          - api/llms-compact.md
         Developers documentation:
-        - developer_guide/*.md
+          - developer_guide/*.md
         Contributors documentation:
-        - contributors_guide/*.md
+          - contributors_guide/*.md
 
 markdown_extensions:
   - pymdownx.details


### PR DESCRIPTION
- Refactored the monolithic `api.md` into domain-specific pages (`map.md`, `pawns.md`, `things.md`, `game.md`, `ui.md`, `system.md`) for vastly improved developer navigation.
- Extracted MkDocs rendering logic into a reusable Jinja2 macro (`_api_template.md`).
- Added a high-level `capabilities.md` matrix to map RimWorld core mechanics and DLCs directly to REST endpoints, solving intent-based discovery.
- Created `all.md` as a monolithic fallback specifically optimized for LLM ingestion (`llms.txt`) and power users.
- Updated root `index.md` and `mkdocs.yml` navigation to support the new hub-and-spoke architecture.