### PR TITLE
Feat/implement alerts endpoint

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/Controllers/Client/UIController.cs
+++ b/Source/RIMAPI/RimworldRestApi/Controllers/Client/UIController.cs
@@ -18,6 +18,15 @@ namespace RIMAPI.BaseControllers
             _windowService = windowService;
         }
 
+        [Get("/api/v1/ui/alerts")]
+        [EndpointMetadata("Retrieve a list of all currently active right-hand screen alerts (e.g., 'Need Defenses', 'Major Break Risk').")]
+        public async Task GetActiveAlerts(HttpListenerContext context)
+        {
+            var result = await GameThreadUtility.InvokeAsync(() => _uiService.GetActiveAlerts());
+
+            await context.SendJsonResponse(result);
+        }
+
         [Post("/api/v1/ui/message")]
         public async Task ShowMessage(HttpListenerContext context)
         {

--- a/Source/RIMAPI/RimworldRestApi/Models/UI/AlertsDto.cs
+++ b/Source/RIMAPI/RimworldRestApi/Models/UI/AlertsDto.cs
@@ -1,0 +1,16 @@
+
+using System.Collections.Generic;
+
+namespace RIMAPI.Models.UI
+{
+    public class AlertDto
+    {
+        public string Label { get; set; }
+        public string Explanation { get; set; }
+
+        // e.g., "Critical", "High", "Medium"
+        public string Priority { get; set; }
+        public List<int> Targets { get; set; }
+        public List<string> Cells { get; set; }
+    }
+}

--- a/Source/RIMAPI/RimworldRestApi/Services/Client/UIService/IUIService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Client/UIService/IUIService.cs
@@ -7,6 +7,7 @@ namespace RIMAPI.Services.Interfaces
 {
     public interface IUIService
     {
+        ApiResult<List<AlertDto>> GetActiveAlerts();
         ApiResult OpenTab(string tabName);
         ApiResult SendLetterSimple(SendLetterRequestDto body);
     }

--- a/Source/RIMAPI/RimworldRestApi/Services/Client/UIService/UIService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Client/UIService/UIService.cs
@@ -4,10 +4,12 @@ using System.Reflection;
 using RimWorld;
 using Verse;
 using RIMAPI.Core;
+using RIMAPI.Models.UI;
 using RIMAPI.Services.Interfaces;
 using RIMAPI.Helpers;
 using System.Linq;
 using RIMAPI.Models;
+using RimWorld.Planet;
 
 namespace RIMAPI.Services
 {
@@ -17,6 +19,84 @@ namespace RIMAPI.Services
             "activeAlerts",
             BindingFlags.Instance | BindingFlags.NonPublic
         );
+
+        public ApiResult<List<AlertDto>> GetActiveAlerts()
+        {
+            if (Current.ProgramState != ProgramState.Playing)
+            {
+                return ApiResult<List<AlertDto>>.Fail("Cannot fetch alerts: Game is not currently playing.");
+            }
+
+            if (Find.Alerts == null)
+            {
+                return ApiResult<List<AlertDto>>.Fail("Alerts system is currently unavailable.");
+            }
+
+            if (ActiveAlertsField == null)
+            {
+                return ApiResult<List<AlertDto>>.Fail("Reflection failed: Could not find the activeAlerts field.");
+            }
+
+            var alertDtos = new List<AlertDto>();
+
+            try
+            {
+                var activeAlerts = (List<Alert>)ActiveAlertsField.GetValue(Find.Alerts);
+
+                if (activeAlerts != null)
+                {
+                    foreach (Alert alert in activeAlerts)
+                    {
+                        try
+                        {
+                            var alertDto = new AlertDto
+                            {
+                                Label = alert.GetLabel(),
+                                Explanation = alert.GetExplanation(),
+                                Priority = alert.Priority.ToString(),
+                                Targets = new List<int>(),
+                                Cells = new List<string>()
+                            };
+
+                            AlertReport report = alert.GetReport();
+                            if (report.AllCulprits != null)
+                            {
+                                foreach (GlobalTargetInfo target in report.AllCulprits)
+                                {
+                                    if (!target.IsValid) continue;
+
+                                    if (target.HasThing)
+                                    {
+                                        alertDto.Targets.Add(target.Thing.thingIDNumber);
+                                    }
+                                    else if (target.HasWorldObject)
+                                    {
+                                        alertDto.Targets.Add(target.WorldObject.ID);
+                                    }
+                                    else if (target.Cell.IsValid)
+                                    {
+                                        alertDto.Cells.Add($"Cell_{target.Cell.x}_{target.Cell.z}");
+                                    }
+                                }
+                            }
+
+                            alertDtos.Add(alertDto);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Warning($"[RIMAPI] Failed to parse alert of type {alert.GetType().Name}: {ex.Message}");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"[RIMAPI] Critical reflection error while reading alerts: {ex}");
+                return ApiResult<List<AlertDto>>.Fail("Internal server error reading memory.");
+            }
+
+            return ApiResult<List<AlertDto>>.Ok(alertDtos);
+        }
 
         public ApiResult OpenTab(string tabName)
         {

--- a/tests/bruno_api_collection/Camera/Screenshot.yml
+++ b/tests/bruno_api_collection/Camera/Screenshot.yml
@@ -11,7 +11,7 @@ http:
     data: |-
       {
         "format": "png",
-        "hide_ui": false
+        "hide_ui": true
       }
   auth: inherit
 

--- a/tests/bruno_api_collection/UI/Alerts List.yml
+++ b/tests/bruno_api_collection/UI/Alerts List.yml
@@ -1,0 +1,15 @@
+info:
+  name: Alerts List
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/ui/alerts"
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/UI/folder.yml
+++ b/tests/bruno_api_collection/UI/folder.yml
@@ -1,0 +1,6 @@
+info:
+  name: UI
+  type: folder
+  seq: 22
+
+request: {}


### PR DESCRIPTION
# Feat: Implement In-Game Alerts Retrieval

## Description
This PR introduces a new endpoint to the API that allows clients to retrieve a list of all currently active in-game alerts and notifications (e.g., "Colonist needs rescue", "Major break risk", "Raid"). 

This feature fully utilizes the new Domain-Driven Design architecture established in the previous refactor.

### Key Changes
- **New Endpoint:** Implemented the REST endpoint to extract active game alerts from the RimWorld engine.
- **Data Models:** Created the corresponding DTOs to cleanly serialize the alert data (labels, descriptions, priorities) for the API response.
- **Service Integration:** Wired the data retrieval logic through the dedicated Client/UI domain service.
- **Testing Setup:** Added Bruno (`.yml`) test configurations to easily validate and interact with the new endpoint.

## Testing Instructions
1. Build the mod and launch a RimWorld colony.
2. Ensure there is at least one active alert on the right side of the screen (e.g., draft a colonist and let them get hungry).
3. Open the Bruno API client.
4. Run the new `Alerts` request from the collection.
5. Verify the JSON response accurately reflects the text and severity of the on-screen alerts.
