### PR TITLE
Feat/Add tutorial endpoints

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/Controllers/Client/LearningController.cs
+++ b/Source/RIMAPI/RimworldRestApi/Controllers/Client/LearningController.cs
@@ -1,0 +1,56 @@
+using System.Threading.Tasks;
+using System.Net;
+using RIMAPI.Core;
+using RIMAPI.Services;
+using RIMAPI.Models;
+using RIMAPI.Http;
+
+namespace RIMAPI.Controllers
+{
+    public class LearningController
+    {
+        private readonly ILearningService _learningService;
+
+        public LearningController(ILearningService learningService)
+        {
+            _learningService = learningService;
+        }
+
+        [Get("/api/v1/client/learning/defs")]
+        public async Task GetConceptsDefs(HttpListenerContext context)
+        {
+            var result = _learningService.GetLearningConceptsDefs();
+            await context.SendJsonResponse(result);
+        }
+
+        [Get("/api/v1/client/learning/all")]
+        public async Task GetAllConcepts(HttpListenerContext context)
+        {
+            var result = _learningService.GetAllConcepts();
+            await context.SendJsonResponse(result);
+        }
+
+        [Get("/api/v1/client/learning/active")]
+        public async Task GetActiveConcepts(HttpListenerContext context)
+        {
+            var result = _learningService.GetActiveConcepts();
+            await context.SendJsonResponse(result);
+        }
+
+        [Get("/api/v1/client/learning/concept")]
+        public async Task GetConcept(HttpListenerContext context)
+        {
+            var defName = RequestParser.GetStringParameter(context, "def_name");
+            var result = _learningService.GetConceptByDef(defName);
+            await context.SendJsonResponse(result);
+        }
+
+        [Post("/api/v1/client/learning/mark-learned")]
+        public async Task MarkLearned(HttpListenerContext context)
+        {
+            var request = await context.Request.ReadBodyAsync<LearningConceptMarkDto>();
+            var result = _learningService.MarkConceptLearned(request);
+            await context.SendJsonResponse(result);
+        }
+    }
+}

--- a/Source/RIMAPI/RimworldRestApi/Models/Client/LearningConceptDto.cs
+++ b/Source/RIMAPI/RimworldRestApi/Models/Client/LearningConceptDto.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace RIMAPI.Models
+{
+    public class LearningConceptDto
+    {
+        public string DefName { get; set; }
+        public string Label { get; set; }
+        public string HelpText { get; set; }
+        public float KnowledgeProgress { get; set; }
+        public bool IsCompleted { get; set; }
+    }
+
+    public class LearningConceptsListDto
+    {
+        public List<string> Defs { get; set; }
+    }
+
+    public class LearningConceptMarkDto
+    {
+        public string DefName { get; set; }
+        public bool IsCompleted { get; set; }
+    }
+}

--- a/Source/RIMAPI/RimworldRestApi/Services/Client/LearningService/ILearningService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Client/LearningService/ILearningService.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using RIMAPI.Core;
+using RIMAPI.Models;
+
+namespace RIMAPI.Services
+{
+    public interface ILearningService
+    {
+        ApiResult<List<string>> GetLearningConceptsDefs();
+        ApiResult<List<LearningConceptDto>> GetAllConcepts();
+        ApiResult<List<LearningConceptDto>> GetActiveConcepts();
+        ApiResult<LearningConceptDto> GetConceptByDef(string defName);
+        ApiResult<bool> MarkConceptLearned(LearningConceptMarkDto request);
+    }
+}

--- a/Source/RIMAPI/RimworldRestApi/Services/Client/LearningService/LearningService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Client/LearningService/LearningService.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.Linq;
+using RIMAPI.Core;
+using RIMAPI.Models;
+using RimWorld;
+using Verse;
+
+namespace RIMAPI.Services
+{
+    public class LearningService : ILearningService
+    {
+        private bool IsTutorAvailable => Current.ProgramState == ProgramState.Playing && Find.Tutor?.learningReadout != null;
+        private const string AvailabilityError = "Learning helper is not available. Game must be playing.";
+
+        public ApiResult<List<string>> GetLearningConceptsDefs()
+        {
+            if (!IsTutorAvailable) return ApiResult<List<string>>.Fail(AvailabilityError);
+
+            var defs = DefDatabase<ConceptDef>.AllDefs
+                .Select(d => d.defName)
+                .ToList();
+
+            return ApiResult<List<string>>.Ok(defs);
+        }
+
+        public ApiResult<List<LearningConceptDto>> GetAllConcepts()
+        {
+            if (!IsTutorAvailable) return ApiResult<List<LearningConceptDto>>.Fail(AvailabilityError);
+
+            var concepts = DefDatabase<ConceptDef>.AllDefs
+                .Select(ToDto)
+                .ToList();
+
+            return ApiResult<List<LearningConceptDto>>.Ok(concepts);
+        }
+
+        public ApiResult<List<LearningConceptDto>> GetActiveConcepts()
+        {
+            if (!IsTutorAvailable) return ApiResult<List<LearningConceptDto>>.Fail(AvailabilityError);
+
+            var activeConcepts = DefDatabase<ConceptDef>.AllDefs
+                .Where(c => Find.Tutor.learningReadout.IsActive(c))
+                .Select(ToDto)
+                .ToList();
+
+            return ApiResult<List<LearningConceptDto>>.Ok(activeConcepts);
+        }
+
+        public ApiResult<LearningConceptDto> GetConceptByDef(string defName)
+        {
+            if (!IsTutorAvailable) return ApiResult<LearningConceptDto>.Fail(AvailabilityError);
+
+            if (string.IsNullOrEmpty(defName))
+            {
+                return ApiResult<LearningConceptDto>.Fail("defName cannot be null or empty.");
+            }
+
+            ConceptDef concept = DefDatabase<ConceptDef>.GetNamedSilentFail(defName);
+            if (concept == null)
+            {
+                return ApiResult<LearningConceptDto>.Fail($"Concept with defName '{defName}' not found.");
+            }
+
+            return ApiResult<LearningConceptDto>.Ok(ToDto(concept));
+        }
+
+        public ApiResult<bool> MarkConceptLearned(LearningConceptMarkDto request)
+        {
+            if (!IsTutorAvailable) return ApiResult<bool>.Fail(AvailabilityError);
+
+            ConceptDef concept = DefDatabase<ConceptDef>.GetNamedSilentFail(request.DefName);
+            if (concept == null)
+            {
+                return ApiResult<bool>.Fail($"Concept with defName '{request.DefName}' not found.");
+            }
+
+            bool currentlyComplete = PlayerKnowledgeDatabase.IsComplete(concept);
+
+            if (request.IsCompleted == currentlyComplete)
+            {
+                return ApiResult<bool>.Ok(true);
+            }
+
+            if (request.IsCompleted)
+            {
+                PlayerKnowledgeDatabase.SetKnowledge(concept, 1f);
+                Find.Tutor.learningReadout.Notify_ConceptNewlyLearned(concept);
+            }
+            else
+            {
+                PlayerKnowledgeDatabase.SetKnowledge(concept, 0f);
+                Find.Tutor.learningReadout.TryActivateConcept(concept);
+            }
+
+            return ApiResult<bool>.Ok(true);
+        }
+
+        /// <summary>
+        /// Centralized mapping logic to convert a ConceptDef to a LearningConceptDto.
+        /// </summary>
+        private LearningConceptDto ToDto(ConceptDef concept)
+        {
+            return new LearningConceptDto
+            {
+                DefName = concept.defName,
+                Label = concept.LabelCap.Resolve(),
+                HelpText = concept.HelpTextAdjusted,
+                KnowledgeProgress = PlayerKnowledgeDatabase.GetKnowledge(concept),
+                IsCompleted = PlayerKnowledgeDatabase.IsComplete(concept)
+            };
+        }
+    }
+}

--- a/tests/bruno_api_collection/Client/Learning/Active Concepts.yml
+++ b/tests/bruno_api_collection/Client/Learning/Active Concepts.yml
@@ -1,0 +1,15 @@
+info:
+  name: Active Concepts
+  type: http
+  seq: 26
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/client/learning/active"
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Client/Learning/All Concepts.yml
+++ b/tests/bruno_api_collection/Client/Learning/All Concepts.yml
@@ -1,0 +1,15 @@
+info:
+  name: All Concepts
+  type: http
+  seq: 29
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/client/learning/all"
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Client/Learning/Concepts Defs.yml
+++ b/tests/bruno_api_collection/Client/Learning/Concepts Defs.yml
@@ -1,0 +1,15 @@
+info:
+  name: Concepts Defs
+  type: http
+  seq: 28
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/client/learning/defs"
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Client/Learning/Get Concept By DefName.yml
+++ b/tests/bruno_api_collection/Client/Learning/Get Concept By DefName.yml
@@ -1,0 +1,19 @@
+info:
+  name: Get Concept By DefName
+  type: http
+  seq: 30
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/client/learning/concept?def_name=Capturing"
+  params:
+    - name: def_name
+      value: Capturing
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Client/Learning/Mark Concept.yml
+++ b/tests/bruno_api_collection/Client/Learning/Mark Concept.yml
@@ -1,0 +1,22 @@
+info:
+  name: Mark Concept
+  type: http
+  seq: 27
+
+http:
+  method: POST
+  url: "{{baseURL}}/api/v1/client/learning/mark-learned"
+  body:
+    type: json
+    data: |-
+      {
+        "def_name": "Mining",
+        "is_completed": false
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Client/Learning/folder.yml
+++ b/tests/bruno_api_collection/Client/Learning/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: Learning
+  type: folder
+  seq: 1
+
+request:
+  auth: inherit

--- a/tests/bruno_api_collection/Client/folder.yml
+++ b/tests/bruno_api_collection/Client/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: Client
+  type: folder
+  seq: 31
+
+request:
+  auth: inherit


### PR DESCRIPTION
Summary

This PR implements the Learning Helper API, providing a robust interface to interact with RimWorld's native "Learning Readiness" (Tutor) system. It allows external clients to query the state of tutorial concepts, track player progress, and programmatically mark lessons as learned or unlearned with full in-game UI/SFX synchronization.
Key Changes
🚀 Features & API Endpoints

Concept Retrieval:

        GET /active: List concepts currently displayed in the player's Learning Helper tray.

        GET /all: List every available ConceptDef in the current game instance.

        GET /{defName}: Fetch detailed metadata (label, help text, progress) for a specific concept.

State Management:

        POST /mark: Update a concept's completion status.

        "Learned" logic: Sets knowledge to 100%, triggers the "Lesson Learned" sound, and clears it from the active readout.

        "Unlearn" logic: Resets knowledge to 0% and re-activates the concept in the Learning Helper for the player to see again.

🧪 Testing & Tooling

Added Bruno API configuration files for all new endpoints under the client/learning namespace.

Verified that marking concepts via API correctly updates the in-game "Learning Helper" window in real-time.