### PR TITLE
Feat/build zone check

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/Controllers/Colony/BuilderController.cs
+++ b/Source/RIMAPI/RimworldRestApi/Controllers/Colony/BuilderController.cs
@@ -38,5 +38,13 @@ namespace RIMAPI.Controllers
             var result = _builderService.PlaceBlueprints(body);
             await context.SendJsonResponse(result);
         }
+
+        [Post("/api/v1/builder/check-zone")]
+        public async Task CheckZone(HttpListenerContext context)
+        {
+            var body = await context.Request.ReadBodyAsync<CheckZoneRequestDto>();
+            var result = _builderService.CheckZone(body);
+            await context.SendJsonResponse(result);
+        }
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Models/BuilderDtos.cs
+++ b/Source/RIMAPI/RimworldRestApi/Models/BuilderDtos.cs
@@ -18,6 +18,13 @@ namespace RIMAPI.Models
         public bool ClearObstacles { get; set; } = true; // Destroy existing things before pasting
     }
 
+    public class CheckZoneRequestDto
+    {
+        public int MapId { get; set; }
+        public PositionDto PointA { get; set; }
+        public PositionDto PointB { get; set; }
+    }
+
     // --- The Blueprint Data Structure ---
     public class BlueprintDto
     {
@@ -41,5 +48,28 @@ namespace RIMAPI.Models
         public int RelX { get; set; }
         public int RelZ { get; set; }
         public int Rotation { get; set; } // 0=North, 1=East, 2=South, 3=West
+    }
+
+    public class CheckZoneResultDto
+    {
+        public bool CanBuild { get; set; }
+        public CheckZoneIssuesDto Issues { get; set; }
+    }
+
+    public class CheckZoneIssuesDto
+    {
+        public List<CheckZoneIssueDto> Terrain { get; set; } = new List<CheckZoneIssueDto>();
+        public List<CheckZoneIssueDto> Ores { get; set; } = new List<CheckZoneIssueDto>();
+        public List<CheckZoneIssueDto> Buildings { get; set; } = new List<CheckZoneIssueDto>();
+        public List<CheckZoneIssueDto> Zones { get; set; } = new List<CheckZoneIssueDto>();
+    }
+
+    public class CheckZoneIssueDto
+    {
+        public int X { get; set; }
+        public int Z { get; set; }
+        public string DefName { get; set; }
+        public string Label { get; set; }
+        public string ZoneType { get; set; }
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/World/BuilderService/BuilderService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/World/BuilderService/BuilderService.cs
@@ -233,5 +233,121 @@ namespace RIMAPI.Services
                 return ApiResult.Fail(ex.Message);
             }
         }
+
+        public ApiResult<CheckZoneResultDto> CheckZone(CheckZoneRequestDto request)
+        {
+            try
+            {
+                var map = MapHelper.GetMapByID(request.MapId);
+                if (map == null) return ApiResult<CheckZoneResultDto>.Fail($"Map {request.MapId} not found.");
+
+                if (request.PointA == null || request.PointB == null)
+                    return ApiResult<CheckZoneResultDto>.Fail("PointA and PointB are required.");
+
+                int minX = Mathf.Min(request.PointA.X, request.PointB.X);
+                int minZ = Mathf.Min(request.PointA.Z, request.PointB.Z);
+                int maxX = Mathf.Max(request.PointA.X, request.PointB.X);
+                int maxZ = Mathf.Max(request.PointA.Z, request.PointB.Z);
+
+                var issues = new CheckZoneIssuesDto();
+                HashSet<Thing> processedThings = new HashSet<Thing>();
+
+                CellRect rect = new CellRect(minX, minZ, (maxX - minX) + 1, (maxZ - minZ) + 1);
+
+                foreach (IntVec3 cell in rect)
+                {
+                    if (!cell.InBounds(map)) continue;
+
+                    // 1. Check Terrain (affordances)
+                    TerrainDef terrain = map.terrainGrid.TerrainAt(cell);
+                    if (terrain != null)
+                    {
+                        bool hasHeavyAffordance = terrain.affordances != null && 
+                            terrain.affordances.Contains(TerrainAffordanceDefOf.Heavy);
+                        if (!hasHeavyAffordance)
+                        {
+                            issues.Terrain.Add(new CheckZoneIssueDto
+                            {
+                                X = cell.x,
+                                Z = cell.z,
+                                DefName = terrain.defName,
+                                Label = terrain.label
+                            });
+                        }
+                    }
+
+                    // 2. Check Things (Ores and Buildings)
+                    List<Thing> things = cell.GetThingList(map);
+                    foreach (var thing in things)
+                    {
+                        if (processedThings.Contains(thing)) continue;
+
+                        // Check for mineable ores
+                        if (thing.def.mineable)
+                        {
+                            processedThings.Add(thing);
+                            issues.Ores.Add(new CheckZoneIssueDto
+                            {
+                                X = thing.Position.x,
+                                Z = thing.Position.z,
+                                DefName = thing.def.defName,
+                                Label = thing.def.label
+                            });
+                        }
+                        // Check for buildings
+                        else if (thing.def.category == ThingCategory.Building)
+                        {
+                            processedThings.Add(thing);
+                            issues.Buildings.Add(new CheckZoneIssueDto
+                            {
+                                X = thing.Position.x,
+                                Z = thing.Position.z,
+                                DefName = thing.def.defName,
+                                Label = thing.def.label
+                            });
+                        }
+                    }
+                }
+
+                // 3. Check Zones (Growing and Stockpile)
+                foreach (Zone zone in map.zoneManager.AllZones)
+                {
+                    if (zone is Zone_Growing || zone is Zone_Stockpile)
+                    {
+                        foreach (IntVec3 cell in zone.cells)
+                        {
+                            if (cell.x >= minX && cell.x <= maxX && cell.z >= minZ && cell.z <= maxZ)
+                            {
+                                issues.Zones.Add(new CheckZoneIssueDto
+                                {
+                                    X = cell.x,
+                                    Z = cell.z,
+                                    DefName = zone.GetType().Name,
+                                    Label = zone.label,
+                                    ZoneType = zone is Zone_Growing ? "Growing" : "Stockpile"
+                                });
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                bool canBuild = issues.Terrain.Count == 0 && 
+                                issues.Ores.Count == 0 && 
+                                issues.Buildings.Count == 0 && 
+                                issues.Zones.Count == 0;
+
+                return ApiResult<CheckZoneResultDto>.Ok(new CheckZoneResultDto
+                {
+                    CanBuild = canBuild,
+                    Issues = issues
+                });
+            }
+            catch (Exception ex)
+            {
+                LogApi.Error($"CheckZone Error: {ex}");
+                return ApiResult<CheckZoneResultDto>.Fail(ex.Message);
+            }
+        }
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/World/BuilderService/IBuilderService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/World/BuilderService/IBuilderService.cs
@@ -8,5 +8,6 @@ namespace RIMAPI.Services
         ApiResult<BlueprintDto> CopyArea(CopyAreaRequestDto request);
         ApiResult PasteArea(PasteAreaRequestDto request);
         ApiResult PlaceBlueprints(PasteAreaRequestDto request);
+        ApiResult<CheckZoneResultDto> CheckZone(CheckZoneRequestDto request);
     }
 }

--- a/tests/bruno_api_collection/Builder/CheckZone.yml
+++ b/tests/bruno_api_collection/Builder/CheckZone.yml
@@ -1,0 +1,23 @@
+info:
+  name: CheckZone
+  type: http
+  seq: 4
+
+http:
+  method: POST
+  url: "{{baseURL}}/api/v1/builder/check-zone"
+  body:
+    type: json
+    data: |-
+      {
+        "mapId": "uuid",
+        "pointA": { "x": 10, "z": 20 },
+        "pointB": { "x": 50, "z": 60 }
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Builder/CheckZone.yml
+++ b/tests/bruno_api_collection/Builder/CheckZone.yml
@@ -10,9 +10,9 @@ http:
     type: json
     data: |-
       {
-        "mapId": "uuid",
-        "pointA": { "x": 10, "z": 20 },
-        "pointB": { "x": 50, "z": 60 }
+        "map_id": "0",
+        "point_a": { "x": 120, "z": 120 },
+        "point_b": { "x": 130, "z": 130 }
       }
   auth: inherit
 


### PR DESCRIPTION
# Builder Check-Zone API Design

## Overview
Add a new endpoint to check if a rectangular area can be used for building heavy constructions.

## Endpoint
`POST /api/v1/builder/check-zone`

## Request
```json
{
  "mapId": "uuid",
  "pointA": { "x": 10, "z": 20 },
  "pointB": { "x": 50, "z": 60 }
}
```

- `mapId`: UUID of the map
- `pointA`: First corner of the area
- `pointB`: Second corner of the area

## Response
```json
{
  "canBuild": false,
  "issues": {
    "terrain": [
      { "x": 15, "z": 25, "defName": "Soil", "label": "Dirt" }
    ],
    "ores": [
      { "x": 30, "z": 40, "defName": "MineableChrome", "label": "Chrome" }
    ],
    "buildings": [
      { "x": 45, "z": 55, "defName": "Table", "label": "Table" }
    ],
    "zones": [
      { "x": 35, "z": 45, "zoneType": "Growing", "label": "Farm 1" },
      { "x": 10, "z": 15, "zoneType": "Stockpile", "label": "Storage" }
    ]
  }
}
```

- `canBuild`: `true` if no issues, `false` otherwise
- `issues`: Grouped by category
  - `terrain`: Cells with terrain lacking Heavy affordance
  - `ores`: Mineable rocks/ores
  - `buildings`: Existing buildings
  - `zones`: Growing or Stockpile zones

## Implementation Details

### Logic
1. **Normalize coordinates** - Ensure min/max X and Z are correct regardless of point order
2. **Iterate all cells** in the rectangular area
3. **For each cell**, check:
   - Terrain: `map.terrainGrid.TerrainAt(cell)` - check if `affordances` does NOT contain Heavy
   - Ores: `cell.GetThingList(map)` - check `thing.def.building.mineable`
   - Buildings: Same thing list, check `thing.def.category == ThingCategory.Building`
4. **Zone check**: Iterate `map.zoneManager.AllZones`, filter by `Zone_Growing` and `Zone_Stockpile`, check if any cell in the zone overlaps with the check area

### Data Structures
- Add `CheckZoneRequestDto` to `BuilderDtos.cs`
- Add `CheckZoneResultDto` to `BuilderDtos.cs` with nested DTOs for each issue type
- Add `CheckZone` method to `IBuilderService` and `BuilderService`
- Add endpoint to `BuilderController`

### RimWorld API References
- `map.terrainGrid.TerrainAt(IntVec3)` - get terrain at cell
- `TerrainDef.affordances` - list of affordance defs (check for Heavy)
- `cell.GetThingList(Map)` - get all things at cell
- `ThingDef.building.mineable` - check if mineable
- `ThingCategory.Building` - category for buildings
- `map.zoneManager.AllZones` - all zones on map
- `Zone_Growing`, `Zone_Stockpile` - zone types to check
- `Zone.cells` - cells belonging to a zone