### PR TITLE
Add window close/list endpoints

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/Controllers/Client/UIController.cs
+++ b/Source/RIMAPI/RimworldRestApi/Controllers/Client/UIController.cs
@@ -42,5 +42,22 @@ namespace RIMAPI.BaseControllers
             var result = _windowService.ShowDialog(body);
             await context.SendJsonResponse(result);
         }
+
+        [Get("/api/v1/ui/windows")]
+        [EndpointMetadata("List currently open windows and whether each force-pauses the game.")]
+        public async Task ListWindows(HttpListenerContext context)
+        {
+            var result = _windowService.ListWindows();
+            await context.SendJsonResponse(result);
+        }
+
+        [Post("/api/v1/ui/window/close")]
+        [EndpointMetadata("Close open windows by type name, or (default) every force-pause window — used to auto-dismiss the colony-name and debug-log popups during unattended runs.")]
+        public async Task CloseWindows(HttpListenerContext context)
+        {
+            var body = await context.Request.ReadBodyAsync<WindowCloseRequestDto>();
+            var result = _windowService.CloseWindows(body);
+            await context.SendJsonResponse(result);
+        }
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Models/UI/WindowDtos.cs
+++ b/Source/RIMAPI/RimworldRestApi/Models/UI/WindowDtos.cs
@@ -28,4 +28,28 @@ namespace RIMAPI.Models
         public string ActionId { get; set; }
         public bool ResolveTree { get; set; } = true; // Close window after click
     }
+
+    // Close one or more open windows by type name.
+    // WindowTypes is matched case-insensitively against each open window's
+    // runtime type name (e.g. "Dialog_NamePlayerSettlement", "EditWindow_Log");
+    // a substring is enough so "Log" closes EditWindow_Log. When omitted/empty,
+    // ForcePauseOnly (default true) closes every window that force-pauses the
+    // game — the unattended-benchmark nuisance case.
+    public class WindowCloseRequestDto
+    {
+        public List<string> WindowTypes { get; set; }
+        public bool ForcePauseOnly { get; set; } = true;
+    }
+
+    public class WindowCloseResultDto
+    {
+        public int ClosedCount { get; set; }
+        public List<string> ClosedWindows { get; set; } = new List<string>();
+    }
+
+    public class OpenWindowDto
+    {
+        public string WindowType { get; set; }
+        public bool ForcePause { get; set; }
+    }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/Client/WindowService/IWindowService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Client/WindowService/IWindowService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using RIMAPI.Core;
 using RIMAPI.Models;
 
@@ -7,5 +8,7 @@ namespace RIMAPI.Services
     {
         ApiResult ShowMessage(WindowMessageRequestDto request);
         ApiResult ShowDialog(WindowDialogRequestDto request);
+        ApiResult<WindowCloseResultDto> CloseWindows(WindowCloseRequestDto request);
+        ApiResult<List<OpenWindowDto>> ListWindows();
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/Client/WindowService/WindowService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Client/WindowService/WindowService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using RIMAPI.Core;
 using RIMAPI.Models;
 using Verse;
@@ -7,6 +9,84 @@ namespace RIMAPI.Services
 {
     public class WindowService : IWindowService
     {
+        public ApiResult<List<OpenWindowDto>> ListWindows()
+        {
+            try
+            {
+                var windows = Find.WindowStack?.Windows;
+                var list = new List<OpenWindowDto>();
+                if (windows != null)
+                {
+                    foreach (var w in windows)
+                    {
+                        list.Add(new OpenWindowDto
+                        {
+                            WindowType = w.GetType().Name,
+                            ForcePause = w.forcePause,
+                        });
+                    }
+                }
+                return ApiResult<List<OpenWindowDto>>.Ok(list);
+            }
+            catch (Exception ex)
+            {
+                return ApiResult<List<OpenWindowDto>>.Fail(ex.Message);
+            }
+        }
+
+        public ApiResult<WindowCloseResultDto> CloseWindows(WindowCloseRequestDto request)
+        {
+            try
+            {
+                request = request ?? new WindowCloseRequestDto();
+                var windowStack = Find.WindowStack;
+                var result = new WindowCloseResultDto();
+                if (windowStack?.Windows == null)
+                    return ApiResult<WindowCloseResultDto>.Ok(result);
+
+                bool byType = request.WindowTypes != null && request.WindowTypes.Count > 0;
+
+                // Snapshot first — removing mutates the live collection.
+                var toClose = windowStack.Windows
+                    .Where(w =>
+                    {
+                        var typeName = w.GetType().Name;
+                        if (byType)
+                        {
+                            return request.WindowTypes.Any(t =>
+                                !string.IsNullOrEmpty(t) &&
+                                typeName.IndexOf(t, StringComparison.OrdinalIgnoreCase) >= 0);
+                        }
+                        // No explicit types: close force-pause windows (the
+                        // unattended-benchmark nuisance: colony-name dialog,
+                        // debug log on error, etc.) when ForcePauseOnly is set.
+                        return !request.ForcePauseOnly || w.forcePause;
+                    })
+                    .ToList();
+
+                foreach (var w in toClose)
+                {
+                    if (windowStack.TryRemove(w, doCloseSound: false))
+                    {
+                        result.ClosedCount++;
+                        result.ClosedWindows.Add(w.GetType().Name);
+                    }
+                }
+
+                if (result.ClosedCount > 0)
+                {
+                    LogApi.Info($"[WindowService] Closed {result.ClosedCount} window(s): "
+                        + string.Join(", ", result.ClosedWindows));
+                }
+
+                return ApiResult<WindowCloseResultDto>.Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return ApiResult<WindowCloseResultDto>.Fail(ex.Message);
+            }
+        }
+
         public ApiResult ShowMessage(WindowMessageRequestDto request)
         {
             try


### PR DESCRIPTION
POST /api/v1/ui/window/close closes open windows by type-name substring, or (default) every window that force-pauses the game. GET /api/v1/ui/windows lists what's open.

The use case is unattended automation — the colony-name dialog and the dev-mode debug log both force-pause and otherwise need someone to click them away mid-run. Follows the existing UIController/WindowService pattern.