### PR TITLE
Add camera follow-pawn endpoint

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/Controllers/Client/CameraController.cs
+++ b/Source/RIMAPI/RimworldRestApi/Controllers/Client/CameraController.cs
@@ -41,6 +41,16 @@ namespace RimworldRestApi.Controllers
             await context.SendJsonResponse(result);
         }
 
+        [Post("/api/v1/camera/follow/pawn")]
+        [EndpointMetadata("Jump/follow the camera to a pawn by id (cinematic capture).")]
+        public async Task JumpToPawn(HttpListenerContext context)
+        {
+            var pawnId = RequestParser.GetIntParameter(context, "pawn_id");
+
+            var result = _cameraService.JumpToPawn(pawnId);
+            await context.SendJsonResponse(result);
+        }
+
         [Post("/api/v1/camera/screenshot")]
         [EndpointMetadata("Capture a screenshot of the game view. Supports resizing and format changes.")]
         public async Task MakeScreenshot(HttpListenerContext context)

--- a/Source/RIMAPI/RimworldRestApi/Services/Client/CameraService/CameraService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Client/CameraService/CameraService.cs
@@ -139,13 +139,15 @@ namespace RIMAPI.Services
         {
             try
             {
-                var thing = ThingIDFinder(pawnId);
-                if (thing == null)
-                    return ApiResult.Fail($"Pawn not found: {pawnId}");
+                var map = Find.CurrentMap;
+                if (map == null)
+                    return ApiResult.Fail("No map is currently active.");
 
-                // Same primitive the position endpoint uses — jump to the
-                // pawn's current cell on the active map.
-                Find.CameraDriver.JumpToCurrentMapLoc(thing.Position);
+                var pawn = FindSpawnedPawn(map, pawnId);
+                if (pawn == null)
+                    return ApiResult.Fail($"Pawn {pawnId} not found on the current map.");
+
+                Find.CameraDriver.JumpToCurrentMapLoc(pawn.Position);
             }
             catch (Exception ex)
             {
@@ -154,15 +156,12 @@ namespace RIMAPI.Services
             return ApiResult.Ok();
         }
 
-        private static Verse.Thing ThingIDFinder(int thingId)
+        private static Pawn FindSpawnedPawn(Map map, int pawnId)
         {
-            foreach (var map in Find.Maps)
+            foreach (var pawn in map.mapPawns.AllPawnsSpawned)
             {
-                foreach (var pawn in map.mapPawns.AllPawnsSpawned)
-                {
-                    if (pawn.thingIDNumber == thingId)
-                        return pawn;
-                }
+                if (pawn.thingIDNumber == pawnId)
+                    return pawn;
             }
             return null;
         }

--- a/Source/RIMAPI/RimworldRestApi/Services/Client/CameraService/CameraService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Client/CameraService/CameraService.cs
@@ -134,6 +134,38 @@ namespace RIMAPI.Services
             }
             return ApiResult.Ok();
         }
+
+        public ApiResult JumpToPawn(int pawnId)
+        {
+            try
+            {
+                var thing = ThingIDFinder(pawnId);
+                if (thing == null)
+                    return ApiResult.Fail($"Pawn not found: {pawnId}");
+
+                // Same primitive the position endpoint uses — jump to the
+                // pawn's current cell on the active map.
+                Find.CameraDriver.JumpToCurrentMapLoc(thing.Position);
+            }
+            catch (Exception ex)
+            {
+                return ApiResult.Fail(ex.Message);
+            }
+            return ApiResult.Ok();
+        }
+
+        private static Verse.Thing ThingIDFinder(int thingId)
+        {
+            foreach (var map in Find.Maps)
+            {
+                foreach (var pawn in map.mapPawns.AllPawnsSpawned)
+                {
+                    if (pawn.thingIDNumber == thingId)
+                        return pawn;
+                }
+            }
+            return null;
+        }
         private static CameraScreenshotResponseDto CaptureScreenshotAsDto(CameraScreenshotRequestDto request)
         {
             request = request ?? new CameraScreenshotRequestDto();

--- a/Source/RIMAPI/RimworldRestApi/Services/Client/CameraService/ICameraService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/Client/CameraService/ICameraService.cs
@@ -11,6 +11,7 @@ namespace RIMAPI.Services
     {
         ApiResult ChangeZoom(int zoom);
         ApiResult MoveToPosition(int x, int y);
+        ApiResult JumpToPawn(int pawnId);
         Task<ApiResult<CameraScreenshotResponseDto>> MakeScreenshotAsync(CameraScreenshotRequestDto request);
         ApiResult<CameraScreenshotResponseDto> MakeScreenshot(CameraScreenshotRequestDto request);
         ApiResult<string> TakeNativeScreenshot(NativeScreenshotRequestDto request);


### PR DESCRIPTION
POST /api/v1/camera/follow/pawn?pawn_id=N jumps the camera to a pawn's current cell — same primitive the existing position endpoint uses. Handy for driving the camera to the action during a recording instead of leaving it parked on the map center.