### PR TITLE
Feat/add mods endpoints

### DIFF
--- a/Source/RIMAPI/RimworldRestApi/Controllers/System/GameController.cs
+++ b/Source/RIMAPI/RimworldRestApi/Controllers/System/GameController.cs
@@ -77,19 +77,45 @@ namespace RIMAPI.Controllers
             await context.SendJsonResponse(result);
         }
 
-        [Get("/api/v1/mods/info")]
-        [EndpointMetadata("Get list of active mods")]
+        [Get("/api/v1/mods/list")]
+        [EndpointMetadata("Get list of active mods or single mod info if package_id/uid is provided")]
         [ResponseExample(typeof(ApiResponse<List<ModInfoDto>>))]
         public async Task GetModsInfo(HttpListenerContext context)
         {
             await _cachingService.CacheAwareResponseAsync(
                 context,
-                "/api/v1/mods/info",
+                "/api/v1/mods/list",
                 dataFactory: () => Task.FromResult(_modService.GetModsInfo()),
                 expiration: TimeSpan.FromMinutes(1),
                 priority: CachePriority.Normal,
                 expirationType: CacheExpirationType.Absolute
             );
+        }
+
+        [Get("/api/v1/mods/info")]
+        [EndpointMetadata("Get single mod info by package_id or uid")]
+        [ResponseExample(typeof(ApiResponse<ModInfoDto>))]
+        public async Task GetModInfo(HttpListenerContext context)
+        {
+            string packageId = RequestParser.HasParameter(context, "package_id")
+                ? RequestParser.GetStringParameter(context, "package_id")
+                : RequestParser.GetStringParameter(context, "uid");
+
+            var result = _modService.GetModInfo(packageId);
+            await context.SendJsonResponse(result);
+        }
+
+        [Get("/api/v1/mods/preview")]
+        [EndpointMetadata("Get mod preview image as base64")]
+        [ResponseExample(typeof(ApiResponse<string>))]
+        public async Task GetModPreview(HttpListenerContext context)
+        {
+            string packageId = RequestParser.HasParameter(context, "package_id")
+                ? RequestParser.GetStringParameter(context, "package_id")
+                : RequestParser.GetStringParameter(context, "uid");
+
+            var result = _modService.GetModPreview(packageId);
+            await context.SendJsonResponse(result);
         }
 
         [Post("/api/v1/game/select-area")]

--- a/Source/RIMAPI/RimworldRestApi/Models/Mods/ModListDto.cs
+++ b/Source/RIMAPI/RimworldRestApi/Models/Mods/ModListDto.cs
@@ -15,5 +15,11 @@ namespace RIMAPI.Models
         public string Name { get; set; }
         public string PackageId { get; set; }
         public int LoadOrder { get; set; }
+        public string Author { get; set; }
+        public string Description { get; set; }
+        public string Url { get; set; }
+        public string Version { get; set; }
+        public List<string> SupportedVersions { get; set; }
+        public string RootDir { get; set; }
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/System/ModService/IModService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/System/ModService/IModService.cs
@@ -8,6 +8,8 @@ namespace RIMAPI.Services
     public interface IModService
     {
         ApiResult<List<ModInfoDto>> GetModsInfo();
+        ApiResult<ModInfoDto> GetModInfo(string packageId);
+        ApiResult<string> GetModPreview(string packageId);
         ApiResult ConfigureMods(ConfigureModsRequestDto body);
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/System/ModService/ModService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/System/ModService/ModService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using RIMAPI.Core;
 using RIMAPI.Models;
@@ -13,12 +14,7 @@ namespace RIMAPI.Services
         {
             try
             {
-                var mods = LoadedModManager.RunningModsListForReading.Select(mod => new ModInfoDto
-                {
-                    Name = mod.Name,
-                    PackageId = mod.PackageId,
-                    LoadOrder = mod.loadOrder,
-                }).ToList();
+                var mods = LoadedModManager.RunningModsListForReading.Select(mod => MapToDto(mod)).ToList();
 
                 return ApiResult<List<ModInfoDto>>.Ok(mods);
             }
@@ -26,6 +22,65 @@ namespace RIMAPI.Services
             {
                 return ApiResult<List<ModInfoDto>>.Fail($"Failed to get mods info: {ex.Message}");
             }
+        }
+
+        public ApiResult<ModInfoDto> GetModInfo(string packageId)
+        {
+            try
+            {
+                var mod = LoadedModManager.RunningModsListForReading.FirstOrDefault(m =>
+                    m.PackageId.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+
+                if (mod == null)
+                    return ApiResult<ModInfoDto>.Fail($"Mod with packageId '{packageId}' not found or not active.");
+
+                return ApiResult<ModInfoDto>.Ok(MapToDto(mod));
+            }
+            catch (Exception ex)
+            {
+                return ApiResult<ModInfoDto>.Fail($"Failed to get mod info for '{packageId}': {ex.Message}");
+            }
+        }
+
+        public ApiResult<string> GetModPreview(string packageId)
+        {
+            try
+            {
+                var mod = LoadedModManager.RunningModsListForReading.FirstOrDefault(m =>
+                    m.PackageId.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+
+                if (mod == null)
+                    return ApiResult<string>.Fail($"Mod with packageId '{packageId}' not found or not active.");
+
+                string previewPath = Path.Combine(mod.RootDir, "About", "preview.png");
+                if (!File.Exists(previewPath))
+                    return ApiResult<string>.Fail($"Preview image not found for mod '{packageId}' at {previewPath}");
+
+                byte[] imageBytes = File.ReadAllBytes(previewPath);
+                string base64Image = Convert.ToBase64String(imageBytes);
+
+                return ApiResult<string>.Ok(base64Image);
+            }
+            catch (Exception ex)
+            {
+                return ApiResult<string>.Fail($"Failed to get mod preview for '{packageId}': {ex.Message}");
+            }
+        }
+
+        private ModInfoDto MapToDto(ModContentPack mod)
+        {
+            return new ModInfoDto
+            {
+                Name = mod.Name,
+                PackageId = mod.PackageId,
+                LoadOrder = mod.loadOrder,
+                Author = mod.ModMetaData?.AuthorsString,
+                Description = mod.ModMetaData?.Description,
+                Url = mod.ModMetaData?.Url,
+                Version = mod.ModMetaData?.ModVersion,
+                SupportedVersions = mod.ModMetaData?.SupportedVersionsReadOnly.Select(v => v.ToString()).ToList(),
+                RootDir = mod.RootDir
+            };
         }
 
         public ApiResult ConfigureMods(ConfigureModsRequestDto body)

--- a/docs/_api_macroses/controllers/GameController.yml
+++ b/docs/_api_macroses/controllers/GameController.yml
@@ -129,12 +129,17 @@ desc: This controller handles the general game functions.
     ```
   method: GET
 /api/v1/mods/info:
-  desc: Manually triggers a complete flush of the API's internal caching system.
+  desc: Returns information about installed mods. Can be filtered by package_id to get detailed info for a single mod.
   curl: |-
-    **Example:**
+    **Example (All mods):**
     ```bash
-    curl --request POST \
+    curl --request GET \
     --url http://localhost:8765/api/v1/mods/info
+    ```
+    **Example (Single mod):**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/info?package_id=RedEyeDev.RIMAPI
     ```
   request: ''
   response: |-
@@ -144,20 +149,44 @@ desc: This controller handles the general game functions.
         "success": true,
         "data": [
             {
-            "name": "Core",
-            "package_id": "ludeon.rimworld",
-            "load_order": 0
-            },
-            {
-            "name": "Royalty",
-            "package_id": "ludeon.rimworld.royalty",
-            "load_order": 1
-            },
-            {
-            "name": "Ideology",
-            "package_id": "ludeon.rimworld.ideology",
-            "load_order": 2
-            },
+            "name": "RIMAPI",
+            "package_id": "RedEyeDev.RIMAPI",
+            "load_order": 3,
+            "author": "RedEyeDev",
+            "description": "RIMAPI is a mod...",
+            "url": "https://...",
+            "version": "1.9.0",
+            "supported_versions": ["1.5", "1.6"],
+            "root_dir": "..."
+            }
+        ],
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
+/api/v1/mods/preview:
+  desc: Returns the mod's preview image as a base64 encoded string.
+  curl: |-
+    **Example:**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/preview?package_id=RedEyeDev.RIMAPI
+    ```
+  request: ''
+  response: |-
+    **Response:**
+    ```json
+    {
+        "success": true,
+        "data": "iVBORw0KGgoAAAANSUhEUgAA...",
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
             {
             "name": "Biotech",
             "package_id": "ludeon.rimworld.biotech",

--- a/docs/_api_macroses/controllers/ru/GameController.ru.yml
+++ b/docs/_api_macroses/controllers/ru/GameController.ru.yml
@@ -128,36 +128,96 @@ desc: Этот контроллер обрабатывает общие игро
     }
     ```
   method: GET
-/api/v1/mods/info:
-  desc: Возвращает информацию об установленных модах.
+/api/v1/mods/get:
+  desc: Возвращает информацию об одном конкретном моде по его package_id или uid.
   curl: |-
-    **Example:**
+    **Пример:**
     ```bash
-    curl --request POST \
-    --url http://localhost:8765/api/v1/mods/info
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/get?uid=RedEyeDev.RIMAPI
     ```
   request: ''
   response: |-
-    **Response:**
+    **Ответ:**
+    ```json
+    {
+        "success": true,
+        "data": {
+            "name": "RIMAPI",
+            "package_id": "RedEyeDev.RIMAPI",
+            "load_order": 3,
+            "author": "RedEyeDev",
+            "description": "...",
+            "url": "...",
+            "version": "1.9.0",
+            "supported_versions": ["1.5", "1.6"],
+            "root_dir": "..."
+        },
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
+/api/v1/mods/info:
+  desc: Возвращает информацию об установленных модах. Можно отфильтровать по package_id, чтобы получить подробную информацию об одном моде.
+  curl: |-
+    **Пример (Все моды):**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/info
+    ```
+    **Пример (Один мод):**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/info?package_id=RedEyeDev.RIMAPI
+    ```
+  request: ''
+  response: |-
+    **Ответ:**
     ```json
     {
         "success": true,
         "data": [
             {
-            "name": "Core",
-            "package_id": "ludeon.rimworld",
-            "load_order": 0
-            },
-            {
-            "name": "Royalty",
-            "package_id": "ludeon.rimworld.royalty",
-            "load_order": 1
-            },
-            {
-            "name": "Ideology",
-            "package_id": "ludeon.rimworld.ideology",
-            "load_order": 2
-            },
+            "name": "RIMAPI",
+            "package_id": "RedEyeDev.RIMAPI",
+            "load_order": 3,
+            "author": "RedEyeDev",
+            "description": "RIMAPI is a mod...",
+            "url": "https://...",
+            "version": "1.9.0",
+            "supported_versions": ["1.5", "1.6"],
+            "root_dir": "..."
+            }
+        ],
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
+/api/v1/mods/preview:
+  desc: Возвращает превью-изображение мода в виде строки, закодированной в base64.
+  curl: |-
+    **Пример:**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/preview?package_id=RedEyeDev.RIMAPI
+    ```
+  request: ''
+  response: |-
+    **Ответ:**
+    ```json
+    {
+        "success": true,
+        "data": "iVBORw0KGgoAAAANSUhEUgAA...",
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
             {
             "name": "Biotech",
             "package_id": "ludeon.rimworld.biotech",

--- a/tests/bruno_api_collection/Game/All Defs.yml
+++ b/tests/bruno_api_collection/Game/All Defs.yml
@@ -1,7 +1,7 @@
 info:
   name: " All Defs"
   type: http
-  seq: 11
+  seq: 9
 
 http:
   method: GET

--- a/tests/bruno_api_collection/Game/Configure.yml
+++ b/tests/bruno_api_collection/Game/Configure.yml
@@ -1,16 +1,12 @@
 info:
   name: Configure
   type: http
-  seq: 7
+  seq: 5
 
 http:
   method: POST
   url: "{{baseURL}}/api/v1/mods/configure"
   auth: inherit
-
-body:
-  json: |-
-    {"package_ids":["brrainz.harmony","ludeon.rimworld","ludeon.rimworld.royalty","ludeon.rimworld.ideology","ludeon.rimworld.biotech","ludeon.rimworld.anomaly","ludeon.rimworld.odyssey","unlimitedhugs.hugslib","redeyedev.rimapi"],"restart_game":true}
 
 settings:
   encodeUrl: true

--- a/tests/bruno_api_collection/Game/Datetime.yml
+++ b/tests/bruno_api_collection/Game/Datetime.yml
@@ -1,7 +1,7 @@
 info:
   name: Datetime
   type: http
-  seq: 12
+  seq: 10
 
 http:
   method: GET

--- a/tests/bruno_api_collection/Game/Deselect.yml
+++ b/tests/bruno_api_collection/Game/Deselect.yml
@@ -1,7 +1,7 @@
 info:
   name: Deselect
   type: http
-  seq: 9
+  seq: 7
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Letter.yml
+++ b/tests/bruno_api_collection/Game/Letter.yml
@@ -1,7 +1,7 @@
 info:
   name: Letter
   type: http
-  seq: 15
+  seq: 13
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Load.yml
+++ b/tests/bruno_api_collection/Game/Load.yml
@@ -1,7 +1,7 @@
 info:
   name: Load
   type: http
-  seq: 17
+  seq: 15
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Menu.yml
+++ b/tests/bruno_api_collection/Game/Menu.yml
@@ -1,7 +1,7 @@
 info:
   name: Menu
   type: http
-  seq: 20
+  seq: 18
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Mod Preview.yml
+++ b/tests/bruno_api_collection/Game/Mod Preview.yml
@@ -1,0 +1,13 @@
+info:
+  name: Mod Preview
+  type: http
+  seq: 7
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/mods/preview?package_id=RedEyeDev.RIMAPI
+  body: none
+  auth: inherit
+
+query:
+  package_id: RedEyeDev.RIMAPI

--- a/tests/bruno_api_collection/Game/Mods/Mod Preview.yml
+++ b/tests/bruno_api_collection/Game/Mods/Mod Preview.yml
@@ -1,0 +1,19 @@
+info:
+  name: Mod Preview
+  type: http
+  seq: 3
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/mods/preview?uid=brrainz.harmony"
+  params:
+    - name: uid
+      value: brrainz.harmony
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Game/Mods/Mods Info.yml
+++ b/tests/bruno_api_collection/Game/Mods/Mods Info.yml
@@ -1,0 +1,19 @@
+info:
+  name: Mods Info
+  type: http
+  seq: 6
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/mods/info?uid=brrainz.harmony"
+  params:
+    - name: uid
+      value: brrainz.harmony
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Game/Mods/Mods List.yml
+++ b/tests/bruno_api_collection/Game/Mods/Mods List.yml
@@ -1,11 +1,11 @@
 info:
-  name: Mods Info
+  name: Mods List
   type: http
-  seq: 6
+  seq: 2
 
 http:
   method: GET
-  url: "{{baseURL}}/api/v1/mods/info"
+  url: "{{baseURL}}/api/v1/mods/list"
   auth: inherit
 
 settings:

--- a/tests/bruno_api_collection/Game/Mods/folder.yml
+++ b/tests/bruno_api_collection/Game/Mods/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: Mods
+  type: folder
+  seq: 21
+
+request:
+  auth: inherit

--- a/tests/bruno_api_collection/Game/Open Tab.yml
+++ b/tests/bruno_api_collection/Game/Open Tab.yml
@@ -1,7 +1,7 @@
 info:
   name: Open Tab
   type: http
-  seq: 10
+  seq: 8
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Quit.yml
+++ b/tests/bruno_api_collection/Game/Quit.yml
@@ -1,7 +1,7 @@
 info:
   name: Quit
   type: http
-  seq: 21
+  seq: 20
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Run In Background Option.yml
+++ b/tests/bruno_api_collection/Game/Run In Background Option.yml
@@ -1,7 +1,7 @@
 info:
   name: Run In Background Option
   type: http
-  seq: 4
+  seq: 3
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Save.yml
+++ b/tests/bruno_api_collection/Game/Save.yml
@@ -1,7 +1,7 @@
 info:
   name: Save
   type: http
-  seq: 16
+  seq: 14
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Select Pawn.yml
+++ b/tests/bruno_api_collection/Game/Select Pawn.yml
@@ -1,7 +1,7 @@
 info:
   name: Select Pawn
   type: http
-  seq: 8
+  seq: 6
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Select-area.yml
+++ b/tests/bruno_api_collection/Game/Select-area.yml
@@ -1,19 +1,12 @@
 info:
   name: Select-area
   type: http
-  seq: 14
+  seq: 12
 
 http:
   method: POST
   url: "{{baseURL}}/api/v1/game/select-area"
   auth: inherit
-
-body:
-  json: |-
-    {
-            "position_a": { "x": 10, "y": 0, "z": 10 },
-            "position_b": { "x": 20, "y": 0, "z": 20 }
-        }
 
 settings:
   encodeUrl: true

--- a/tests/bruno_api_collection/Game/Settings.yml
+++ b/tests/bruno_api_collection/Game/Settings.yml
@@ -1,7 +1,7 @@
 info:
   name: Settings
   type: http
-  seq: 20
+  seq: 19
 
 http:
   method: GET

--- a/tests/bruno_api_collection/Game/Start DevQuick Game.yml
+++ b/tests/bruno_api_collection/Game/Start DevQuick Game.yml
@@ -1,7 +1,7 @@
 info:
   name: Start DevQuick Game
   type: http
-  seq: 18
+  seq: 16
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Start.yml
+++ b/tests/bruno_api_collection/Game/Start.yml
@@ -1,29 +1,12 @@
 info:
   name: Start
   type: http
-  seq: 19
+  seq: 17
 
 http:
   method: POST
   url: "{{baseURL}}/api/v1/game/start"
   auth: inherit
-
-body:
-  json: |-
-    {
-            "storyteller_name": "Randy",
-            "difficulty_name": "Peaceful",
-            "map_size": 120,
-            "permadeath": false,
-            "planet_coverage": 0.1,
-            "world_seed": "rickroll",
-            "starting_tile": "7298",
-            "starting_season": "2",
-            "overall_rainfall": 2,
-            "overall_temperature": 2,
-            "overall_population": 2,
-            "landmark_density": 2
-        }
 
 settings:
   encodeUrl: true

--- a/tests/bruno_api_collection/Game/Tile.yml
+++ b/tests/bruno_api_collection/Game/Tile.yml
@@ -1,7 +1,7 @@
 info:
   name: Tile
   type: http
-  seq: 13
+  seq: 11
 
 http:
   method: GET

--- a/tests/bruno_api_collection/Game/Version.yml
+++ b/tests/bruno_api_collection/Game/Version.yml
@@ -1,7 +1,7 @@
 info:
   name: Version
   type: http
-  seq: 5
+  seq: 4
 
 http:
   method: GET


### PR DESCRIPTION
## Mod management & preview endpoints

Adds dedicated endpoints for querying loaded mod metadata and retrieving
preview images, rounding out the System domain's coverage of the running
mod list.

### Changes

**API (`feat(api)`)**
- `GET /api/v1/mods/list` — active mod list with 1-minute cache (replaces
  the old `/api/v1/mods/info` list route; existing clients need to update
  the URL)
- `GET /api/v1/mods/info?package_id=<id>` — single mod metadata, also
  accepts `uid` as a fallback parameter
- `GET /api/v1/mods/preview?package_id=<id>` — mod's `About/preview.png`
  returned as a base64 string; 404 if no preview file exists
- `ModInfoDto` extended with `author`, `description`, `url`, `version`,
  `supported_versions`, `root_dir`

**Docs (`docs`)**
- `GameController.yml` and `GameController.ru.yml` updated with request /
  response examples for all three new endpoints

**Bruno (`ref(bruno)`)**
- `Game/Mods/` subfolder created; `Mods List`, `Mods Info`, and
  `Mod Preview` configs added
- Old flat `Mods Info.yml` moved into the subfolder and renamed

### Breaking change

`GET /api/v1/mods/info` previously returned the full list of active mods.
It now returns a single mod by `package_id`. Clients using the list
behaviour must switch to `/api/v1/mods/list`.
