### PR TITLE
Ref/cleanup

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -6,10 +6,12 @@
   <author>RedEyeDev</author>
   <modVersion>1.9.0</modVersion>
   <url>https://ilyachichkov.github.io/RIMAPI/index.html</url>
+
   <supportedVersions>
     <li>1.5</li>
     <li>1.6</li>
   </supportedVersions>
+
   <modDependencies>
 		<li>
 			<packageId>brrainz.harmony</packageId>
@@ -18,4 +20,10 @@
 			<steamWorkshopUrl>https://steamcommunity.com/workshop/filedetails/?id=2009463077</steamWorkshopUrl>
 		</li>
 	</modDependencies>
+
+	<loadAfter>
+		<li>brrainz.harmony</li>
+		<li>Ludeon.RimWorld</li>
+	</loadAfter>
+
 </ModMetaData>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,262 @@
+# RIMAPI — AI Agent Guide
+
+RIMAPI is a RimWorld mod that embeds a REST API server directly into the game, exposing 120+ endpoints on `http://localhost:8765/` so external applications can read and interact with the colony in real-time.
+
+## Tech Stack
+
+- **Language:** C# 9.0 targeting .NET Framework 4.7.2
+- **Serialization:** Newtonsoft.Json 13.0 with a custom `SnakeCaseContractResolver`
+- **Patching:** Harmony 2.3.3 for runtime method hooks
+- **RimWorld versions:** 1.5 and 1.6 (both built from the same source via conditional compilation)
+- **Build configs:** `Debug`, `Release-1.5`, `Release-1.6`
+
+## Repository Layout
+
+```
+My_test_mod/
+├── About/                        # Mod metadata (About.xml, Manifest.xml, preview.png)
+├── Source/RIMAPI/                # All C# source
+│   ├── RIMAPI_Mod.cs             # Entry point, settings UI
+│   ├── RIMAPI_GameComponent.cs   # Server lifecycle, tick processor
+│   ├── RIMAPI_Settings.cs        # User-configurable settings
+│   └── RimworldRestApi/
+│       ├── Core/                 # HTTP server, router, DI, caching, SSE, logging
+│       ├── Controllers/          # 25 controllers across 5 domains (thin — parse + respond only)
+│       ├── Services/             # Business logic; abstracts RimWorld's internal API
+│       ├── Models/               # DTOs — never expose RimWorld internals in responses
+│       ├── Hooks/                # Harmony patches that publish SSE events
+│       ├── Helpers/              # Reusable utility functions
+│       └── Camera/               # UDP camera streaming
+├── 1.5/Assemblies/               # Compiled DLL for RimWorld 1.5
+├── 1.6/Assemblies/               # Compiled DLL for RimWorld 1.6
+├── Libraries/                    # Newtonsoft.Json.dll
+├── docs/                         # MkDocs documentation source
+│   ├── api/                      # Endpoint reference by domain
+│   ├── developer_guide/          # API conventions, extension guide, endpoint guide
+│   └── contributors_guide/       # Architecture, contributing, release flow
+├── tests/                        # Python integration scripts + Bruno API collection
+├── scripts/                      # bump_version.py, doc generation helpers
+├── RimApi.sln / RimApi.csproj    # Visual Studio solution
+└── CHANGELOG.md
+```
+
+## Architecture
+
+### Request Pipeline
+
+```
+HTTP Client
+  → HttpListener (background thread)
+  → Request Queue  (producer-consumer, thread-safe)
+  → ApiServer.ProcessTick()  (main Unity thread, ≤10 req/tick)
+  → Router  (attribute-based pattern matching)
+  → Controller  (parse request, call service, return ApiResult)
+  → Service  (all RimWorld API access lives here)
+  → JSON response
+```
+
+All game-state mutations happen on the main thread automatically. Response latency depends on game frame rate and queue depth.
+
+### Dependency Injection
+
+Custom DI container (`ServiceCollection` + `ServiceProvider`). Singletons: `ApiServer`, `SseService`, `EventRegistry`. Controllers are transient. Constructor injection is used throughout.
+
+### Server-Sent Events (SSE)
+
+`SseService` broadcasts real-time game events (pawn death, incidents, map changes, etc.) to connected clients. Events are published from Harmony hooks in `Hooks/`. Extensions can publish custom events.
+
+### Extension System
+
+Other mods can add endpoints by implementing `IRimApiExtension`. The registry discovers implementations via reflection, isolates their errors, and registers their services and routes automatically.
+
+### Caching
+
+`CachingService` provides in-memory TTL caching with strategies: Absolute, Sliding, Never, GameTick-based. Priority levels: Low, Normal, High, Critical. Controllers call `CacheAwareResponseAsync(...)` for cached endpoints.
+
+## Coding Conventions
+
+### Controllers are thin
+
+Controllers only parse the request and return a response. All logic goes in services. No RimWorld API calls in controllers.
+
+```csharp
+// Good
+[Get("/api/v1/colonists")]
+public async Task GetColonists(HttpListenerContext context)
+{
+    var colonists = _colonistService.GetAll();
+    await context.WriteJsonAsync(ApiResult<List<ColonistDto>>.Ok(colonists));
+}
+```
+
+### Services abstract RimWorld
+
+Services own all interaction with RimWorld internals. Never let a DTO or controller touch `Verse.*` types directly — map everything to a DTO first.
+
+### Models (DTOs)
+
+- All DTOs live in `Source/RIMAPI/RimworldRestApi/Models/`
+- Organized by domain: `Pawns/`, `Game/`, `Map/`, `Items/`, `UI/`, `Camera/`, etc.
+- C# PascalCase properties auto-convert to `snake_case` JSON keys via `SnakeCaseContractResolver`
+- A few DTOs override this with explicit `[JsonProperty("key")]` (e.g. `WorkPriorityRequestDto`)
+
+### Helpers vs Services
+
+- **Helpers** contain stateless reusable code (pure functions, conversions)
+- **Services** orchestrate workflows and hold state/dependencies
+
+## API Conventions
+
+### Response Envelope
+
+Every response is wrapped:
+
+```json
+{
+  "success": true,
+  "data": { ... },
+  "errors": [],
+  "warnings": [],
+  "timestamp": "2026-03-21T23:26:03.876Z"
+}
+```
+
+Use `ApiResult<T>` (with data) or `ApiResult` (no data). `data` is omitted when null.
+
+### HTTP Status Codes
+
+| Status | Trigger |
+|--------|---------|
+| 200 | `success: true` |
+| 400 | Error message contains "validation" |
+| 401 | Error message contains "unauthorized" |
+| 404 | Error message contains "not found" |
+| 411 | POST without `Content-Length` header |
+| 500 | All other errors |
+
+### JSON Naming
+
+All keys use `snake_case`. Examples:
+
+| C# Property | JSON Key |
+|-------------|----------|
+| `MapId` | `map_id` |
+| `IsDrafted` | `is_drafted` |
+| `PlantDef` | `plant_def` |
+| `X`, `Y`, `Z` | `x`, `y`, `z` |
+
+### POST Requests
+
+All POST requests must include a `Content-Length` header (required by .NET's `HttpListener`). Send `{}` if the body is empty.
+
+### IDs
+
+Pawn, building, zone, and map IDs are **integers** (RimWorld's internal `thingIDNumber`).
+
+```json
+{ "pawn_id": 184 }   // correct
+{ "pawn_id": "184" } // wrong — deserializes as 0
+```
+
+### defNames
+
+RimWorld definition names are **case-sensitive**: `Plant_Potato`, `Electricity`, `Growing`.
+
+### Coordinates
+
+RimWorld uses 3D coords; Y is always `0` for ground level. Rectangular areas use `point_a` + `point_b`.
+
+```json
+{ "position": {"x": 120, "y": 0, "z": 130} }
+```
+
+### Query Parameters
+
+Query param names are **not** snake_cased — use the exact name from the `RequestParser` call in the controller.
+
+## Adding a New Endpoint
+
+1. **Create a DTO** in the appropriate `Models/` subdirectory.
+2. **Create a service interface + implementation** in `Services/<domain>/`.
+3. **Register the service** in `ApiServer.CreateDefaultServiceProvider()`.
+4. **Create or update a controller** in `Controllers/<domain>/`, inject the service, add a `[Get]`/`[Post]`/etc. method.
+5. **Update docs** in `docs/_endpoints_examples/examples.yml` (required for release).
+
+Route attributes are discovered automatically — no manual registration needed.
+
+## Build & Versioning
+
+### Building
+
+Open `Source/RimApi.sln`. Build with `Release-1.5` for RimWorld 1.5 output to `1.5/Assemblies/`, or `Release-1.6` for `1.6/Assemblies/`. Both must be built before releasing.
+
+Conditional compilation: `RIMWORLD_1_5` and `RIMWORLD_1_6` symbols are set per configuration.
+
+### Version Bump
+
+Never edit version strings manually. Run from the repo root:
+
+```bash
+python scripts/bump_version.py 1.9.1
+```
+
+This updates `About/About.xml`, `About/Manifest.xml`, `Source/RIMAPI/RimApi.csproj`, and doc metadata atomically.
+
+## Testing
+
+### Integration Tests (Python)
+
+Located in `tests/`. Require RIMAPI running in-game.
+
+```bash
+python tests/spawn_and_edit.py      # pawn creation & modification
+python tests/spawn_battle_test.py   # combat scenarios
+python tests/sse_debugger.py        # SSE event stream debug
+```
+
+### Bruno API Collection
+
+`tests/bruno_api_collection/` contains pre-configured HTTP requests for manual endpoint testing. The full collection should pass before any release.
+
+### Manual Checklist
+
+Before submitting a PR:
+1. Mod loads without errors in RimWorld
+2. API server starts on the configured port
+3. New endpoint responds with correct data and status codes
+4. A few existing endpoints still work (regression check)
+5. Error paths return proper 4xx/5xx responses
+
+## Release Process
+
+1. Finalize `CHANGELOG.md` — move `[Unreleased]` to the new version + date
+2. Run doc formatting/validation scripts in `scripts/docs/`
+3. Run `python scripts/bump_version.py <version>`
+4. Build for both 1.5 and 1.6
+5. Commit: `git commit -m "Release v1.9.1"` then `git tag -a v1.9.1 -m "Release v1.9.1"`
+6. Push commit and tag
+
+## Domain Map
+
+| Domain | Controllers | Key Services |
+|--------|-------------|-------------|
+| System | GameController, ThingsController, DevToolsController | IGameStateService, IGameDataService, IDevToolsService |
+| Colony | BillController, ResearchController, OrderController, TradeController, GameEventsController, BuilderController, ColonistsWorkController | IBillService, IResearchService, ITradeService, IIncidentService, IBuilderService |
+| Pawns | PawnController, PawnInfoController, PawnEditController, PawnJobController, PawnSocialController, PawnSpawnController | IColonistService, IPawnInfoService, IPawnEditService, IPawnJobService, IPawnSocialService, IPawnSpawnService |
+| World | MapController, GlobalMapController, FactionController | IMapService, IGlobalMapService, IFactionService, IBuildingService |
+| Client | UIController, CameraController, ImagesController, OverlayController, LearningController | IUIService, ICameraService, IImageService, IOverlayService, ILearningService |
+| AI | LordController | — |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| [Source/RIMAPI/RIMAPI_Mod.cs](Source/RIMAPI/RIMAPI_Mod.cs) | Mod entry point, Harmony init, settings UI |
+| [Source/RIMAPI/RIMAPI_GameComponent.cs](Source/RIMAPI/RIMAPI_GameComponent.cs) | Server lifecycle, request tick processor |
+| [Source/RIMAPI/RimworldRestApi/Core/ApiServer.cs](Source/RIMAPI/RimworldRestApi/Core/ApiServer.cs) | HTTP orchestration, DI setup, route registration |
+| [Source/RIMAPI/RimworldRestApi/Core/Routing/Router.cs](Source/RIMAPI/RimworldRestApi/Core/Routing/Router.cs) | Attribute-based routing |
+| [Source/RIMAPI/RimworldRestApi/Core/SSE/SseService.cs](Source/RIMAPI/RimworldRestApi/Core/SSE/SseService.cs) | Real-time event broadcasting |
+| [Source/RIMAPI/RimworldRestApi/Core/Caching/CachingService.cs](Source/RIMAPI/RimworldRestApi/Core/Caching/CachingService.cs) | TTL caching |
+| [docs/api/index.md](docs/api/index.md) | Master API endpoint reference |
+| [docs/developer_guide/api_conventions.md](docs/developer_guide/api_conventions.md) | Request/response standards |
+| [docs/contributors_guide/architecture.md](docs/contributors_guide/architecture.md) | Architecture diagrams and lifecycle flows |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Status](https://img.shields.io/badge/Status-In_Progress-blue.svg)
 ![RimWorld Version](https://img.shields.io/badge/RimWorld-v1.5+-blue.svg)
-![API Version](https://img.shields.io/badge/API-v0.1.0-green.svg)
+![API Version](https://img.shields.io/badge/API-v1-green.svg)
 ![Build](https://github.com/IlyaChichkov/RIMAPI/actions/workflows/release_build.yml/badge.svg)
 ![Release](https://img.shields.io/github/v/release/IlyaChichkov/RIMAPI)
 

--- a/Source/RIMAPI/RIMAPI_Mod.cs
+++ b/Source/RIMAPI/RIMAPI_Mod.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Reflection;
+using HarmonyLib;
 using RIMAPI.Core;
 using UnityEngine;
 using Verse;
@@ -15,6 +16,18 @@ namespace RIMAPI
         /// Global access to the loaded mod settings.
         /// </summary>
         public static RIMAPI_Settings Settings;
+
+        private static readonly string _gitHash = ReadGitHash();
+
+        private static string ReadGitHash()
+        {
+            var attr = typeof(RIMAPI_Mod).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            if (attr == null) return string.Empty;
+            var full = attr.InformationalVersion;
+            var plus = full.IndexOf('+');
+            return plus >= 0 ? full.Substring(plus + 1) : string.Empty;
+        }
 
         /// <summary>
         /// Global reference to the Server-Sent Events (SSE) service.
@@ -66,7 +79,7 @@ namespace RIMAPI
 
             // --- Version Information ---
             list.Label("RIMAPI.Version".Translate());
-            list.Label(Settings.version.ToString());
+            list.Label(_gitHash.Length > 0 ? $"{Settings.version} ({_gitHash})" : Settings.version);
 
             list.Label("RIMAPI.APIVersion".Translate());
             list.Label(Settings.apiVersion.ToString());

--- a/Source/RIMAPI/RimApi.csproj
+++ b/Source/RIMAPI/RimApi.csproj
@@ -26,6 +26,18 @@
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
 
+  <!-- Embed git hash into AssemblyInformationalVersion as "1.9.0+<hash>" -->
+  <Target Name="SetSourceRevisionId" BeforeTargets="AddSourceRevisionToInformationalVersion">
+    <Exec Command="git rev-parse --short HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true"
+          WorkingDirectory="$(MSBuildProjectDirectory)">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitRevisionRaw" />
+    </Exec>
+    <PropertyGroup>
+      <SourceRevisionId Condition="'$(_GitRevisionRaw.Trim())' != ''">$(_GitRevisionRaw.Trim())</SourceRevisionId>
+      <SourceRevisionId Condition="'$(_GitRevisionRaw.Trim())' == ''">unknown</SourceRevisionId>
+    </PropertyGroup>
+  </Target>
+
   <ItemGroup>
     <!-- RimWorld 1.5 dependencies -->
     <PackageReference

--- a/Source/RIMAPI/RimworldRestApi/Controllers/System/GameController.cs
+++ b/Source/RIMAPI/RimworldRestApi/Controllers/System/GameController.cs
@@ -77,19 +77,45 @@ namespace RIMAPI.Controllers
             await context.SendJsonResponse(result);
         }
 
-        [Get("/api/v1/mods/info")]
-        [EndpointMetadata("Get list of active mods")]
+        [Get("/api/v1/mods/list")]
+        [EndpointMetadata("Get list of active mods or single mod info if package_id/uid is provided")]
         [ResponseExample(typeof(ApiResponse<List<ModInfoDto>>))]
         public async Task GetModsInfo(HttpListenerContext context)
         {
             await _cachingService.CacheAwareResponseAsync(
                 context,
-                "/api/v1/mods/info",
+                "/api/v1/mods/list",
                 dataFactory: () => Task.FromResult(_modService.GetModsInfo()),
                 expiration: TimeSpan.FromMinutes(1),
                 priority: CachePriority.Normal,
                 expirationType: CacheExpirationType.Absolute
             );
+        }
+
+        [Get("/api/v1/mods/info")]
+        [EndpointMetadata("Get single mod info by package_id or uid")]
+        [ResponseExample(typeof(ApiResponse<ModInfoDto>))]
+        public async Task GetModInfo(HttpListenerContext context)
+        {
+            string packageId = RequestParser.HasParameter(context, "package_id")
+                ? RequestParser.GetStringParameter(context, "package_id")
+                : RequestParser.GetStringParameter(context, "uid");
+
+            var result = _modService.GetModInfo(packageId);
+            await context.SendJsonResponse(result);
+        }
+
+        [Get("/api/v1/mods/preview")]
+        [EndpointMetadata("Get mod preview image as base64")]
+        [ResponseExample(typeof(ApiResponse<string>))]
+        public async Task GetModPreview(HttpListenerContext context)
+        {
+            string packageId = RequestParser.HasParameter(context, "package_id")
+                ? RequestParser.GetStringParameter(context, "package_id")
+                : RequestParser.GetStringParameter(context, "uid");
+
+            var result = _modService.GetModPreview(packageId);
+            await context.SendJsonResponse(result);
         }
 
         [Post("/api/v1/game/select-area")]

--- a/Source/RIMAPI/RimworldRestApi/Models/Mods/ModListDto.cs
+++ b/Source/RIMAPI/RimworldRestApi/Models/Mods/ModListDto.cs
@@ -15,5 +15,11 @@ namespace RIMAPI.Models
         public string Name { get; set; }
         public string PackageId { get; set; }
         public int LoadOrder { get; set; }
+        public string Author { get; set; }
+        public string Description { get; set; }
+        public string Url { get; set; }
+        public string Version { get; set; }
+        public List<string> SupportedVersions { get; set; }
+        public string RootDir { get; set; }
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/System/ModService/IModService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/System/ModService/IModService.cs
@@ -8,6 +8,8 @@ namespace RIMAPI.Services
     public interface IModService
     {
         ApiResult<List<ModInfoDto>> GetModsInfo();
+        ApiResult<ModInfoDto> GetModInfo(string packageId);
+        ApiResult<string> GetModPreview(string packageId);
         ApiResult ConfigureMods(ConfigureModsRequestDto body);
     }
 }

--- a/Source/RIMAPI/RimworldRestApi/Services/System/ModService/ModService.cs
+++ b/Source/RIMAPI/RimworldRestApi/Services/System/ModService/ModService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using RIMAPI.Core;
 using RIMAPI.Models;
@@ -13,12 +14,7 @@ namespace RIMAPI.Services
         {
             try
             {
-                var mods = LoadedModManager.RunningModsListForReading.Select(mod => new ModInfoDto
-                {
-                    Name = mod.Name,
-                    PackageId = mod.PackageId,
-                    LoadOrder = mod.loadOrder,
-                }).ToList();
+                var mods = LoadedModManager.RunningModsListForReading.Select(mod => MapToDto(mod)).ToList();
 
                 return ApiResult<List<ModInfoDto>>.Ok(mods);
             }
@@ -26,6 +22,65 @@ namespace RIMAPI.Services
             {
                 return ApiResult<List<ModInfoDto>>.Fail($"Failed to get mods info: {ex.Message}");
             }
+        }
+
+        public ApiResult<ModInfoDto> GetModInfo(string packageId)
+        {
+            try
+            {
+                var mod = LoadedModManager.RunningModsListForReading.FirstOrDefault(m =>
+                    m.PackageId.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+
+                if (mod == null)
+                    return ApiResult<ModInfoDto>.Fail($"Mod with packageId '{packageId}' not found or not active.");
+
+                return ApiResult<ModInfoDto>.Ok(MapToDto(mod));
+            }
+            catch (Exception ex)
+            {
+                return ApiResult<ModInfoDto>.Fail($"Failed to get mod info for '{packageId}': {ex.Message}");
+            }
+        }
+
+        public ApiResult<string> GetModPreview(string packageId)
+        {
+            try
+            {
+                var mod = LoadedModManager.RunningModsListForReading.FirstOrDefault(m =>
+                    m.PackageId.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+
+                if (mod == null)
+                    return ApiResult<string>.Fail($"Mod with packageId '{packageId}' not found or not active.");
+
+                string previewPath = Path.Combine(mod.RootDir, "About", "preview.png");
+                if (!File.Exists(previewPath))
+                    return ApiResult<string>.Fail($"Preview image not found for mod '{packageId}' at {previewPath}");
+
+                byte[] imageBytes = File.ReadAllBytes(previewPath);
+                string base64Image = Convert.ToBase64String(imageBytes);
+
+                return ApiResult<string>.Ok(base64Image);
+            }
+            catch (Exception ex)
+            {
+                return ApiResult<string>.Fail($"Failed to get mod preview for '{packageId}': {ex.Message}");
+            }
+        }
+
+        private ModInfoDto MapToDto(ModContentPack mod)
+        {
+            return new ModInfoDto
+            {
+                Name = mod.Name,
+                PackageId = mod.PackageId,
+                LoadOrder = mod.loadOrder,
+                Author = mod.ModMetaData?.AuthorsString,
+                Description = mod.ModMetaData?.Description,
+                Url = mod.ModMetaData?.Url,
+                Version = mod.ModMetaData?.ModVersion,
+                SupportedVersions = mod.ModMetaData?.SupportedVersionsReadOnly.Select(v => v.ToString()).ToList(),
+                RootDir = mod.RootDir
+            };
         }
 
         public ApiResult ConfigureMods(ConfigureModsRequestDto body)

--- a/docs/_api_macroses/controllers/CameraController.yml
+++ b/docs/_api_macroses/controllers/CameraController.yml
@@ -48,6 +48,31 @@ desc: |-
     }
     ```
   method: POST
+/api/v1/camera/follow/pawn:
+  desc: |-
+    Jumps the camera to the position of a pawn identified by their numeric ID.
+    Useful for cinematic capture or tracking a specific colonist, animal, or enemy.
+  method: POST
+  tags:
+  - UI
+  - Camera
+  curl: |-
+    **Example:**
+    ```bash
+    curl --request POST \
+    --url 'http://localhost:8765/api/v1/camera/follow/pawn?pawn_id=526'
+    ```
+  request: ''
+  response: |-
+    **Response:**
+    ```json
+    {
+    "success": true,
+    "errors": [],
+    "warnings": [],
+    "timestamp": "2025-12-09T19:16:06.4839322Z"
+    }
+    ```
 /api/v1/stream/start:
   desc: |-
     Starts a live video stream of the game's current camera view.

--- a/docs/_api_macroses/controllers/GameController.yml
+++ b/docs/_api_macroses/controllers/GameController.yml
@@ -129,12 +129,17 @@ desc: This controller handles the general game functions.
     ```
   method: GET
 /api/v1/mods/info:
-  desc: Manually triggers a complete flush of the API's internal caching system.
+  desc: Returns information about installed mods. Can be filtered by package_id to get detailed info for a single mod.
   curl: |-
-    **Example:**
+    **Example (All mods):**
     ```bash
-    curl --request POST \
+    curl --request GET \
     --url http://localhost:8765/api/v1/mods/info
+    ```
+    **Example (Single mod):**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/info?package_id=RedEyeDev.RIMAPI
     ```
   request: ''
   response: |-
@@ -144,20 +149,44 @@ desc: This controller handles the general game functions.
         "success": true,
         "data": [
             {
-            "name": "Core",
-            "package_id": "ludeon.rimworld",
-            "load_order": 0
-            },
-            {
-            "name": "Royalty",
-            "package_id": "ludeon.rimworld.royalty",
-            "load_order": 1
-            },
-            {
-            "name": "Ideology",
-            "package_id": "ludeon.rimworld.ideology",
-            "load_order": 2
-            },
+            "name": "RIMAPI",
+            "package_id": "RedEyeDev.RIMAPI",
+            "load_order": 3,
+            "author": "RedEyeDev",
+            "description": "RIMAPI is a mod...",
+            "url": "https://...",
+            "version": "1.9.0",
+            "supported_versions": ["1.5", "1.6"],
+            "root_dir": "..."
+            }
+        ],
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
+/api/v1/mods/preview:
+  desc: Returns the mod's preview image as a base64 encoded string.
+  curl: |-
+    **Example:**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/preview?package_id=RedEyeDev.RIMAPI
+    ```
+  request: ''
+  response: |-
+    **Response:**
+    ```json
+    {
+        "success": true,
+        "data": "iVBORw0KGgoAAAANSUhEUgAA...",
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
             {
             "name": "Biotech",
             "package_id": "ludeon.rimworld.biotech",

--- a/docs/_api_macroses/controllers/WindowController.yml
+++ b/docs/_api_macroses/controllers/WindowController.yml
@@ -30,6 +30,80 @@ desc: The **Window Controller** manages in-game windows and dialogs.
     }
     ```
   method: POST
+/api/v1/ui/windows:
+  desc: |-
+    Returns a list of all currently open in-game windows,
+    along with whether each one force-pauses the game.
+    Useful for detecting blocking dialogs during unattended runs.
+  curl: |-
+    **Example:**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/ui/windows
+    ```
+  request: ''
+  response: |-
+    **Response:**
+    ```json
+    {
+        "success": true,
+        "data": [
+            {
+                "window_type": "Dialog_NamePlayerSettlement",
+                "force_pause": true
+            },
+            {
+                "window_type": "MainTabWindow_Inspect",
+                "force_pause": false
+            }
+        ],
+        "errors": [],
+        "warnings": [],
+        "timestamp": "2025-12-10T19:53:16.733319Z"
+    }
+    ```
+  method: GET
+/api/v1/ui/window/close:
+  desc: |-
+    Closes open in-game windows by type name. When `window_types` is omitted or empty
+    and `force_pause_only` is `true` (the default), every window that force-pauses the
+    game is closed — the typical use case for dismissing colony-name or debug-log popups
+    during unattended runs. Type matching is case-insensitive substring: `"Log"` matches
+    `EditWindow_Log`.
+  curl: |-
+    **Example:**
+    ```bash
+    curl --request POST \
+    --url http://localhost:8765/api/v1/ui/window/close \
+    --header 'content-type: application/json' \
+    --data '{
+        "window_types": ["Dialog_NamePlayerSettlement"],
+        "force_pause_only": false
+    }'
+    ```
+  request: |-
+    **Request:**
+    ```json
+    {
+        "window_types": ["Dialog_NamePlayerSettlement"],
+        "force_pause_only": false
+    }
+    ```
+  response: |-
+    **Response:**
+    ```json
+    {
+        "success": true,
+        "data": {
+            "closed_count": 1,
+            "closed_windows": ["Dialog_NamePlayerSettlement"]
+        },
+        "errors": [],
+        "warnings": [],
+        "timestamp": "2025-12-10T19:53:16.733319Z"
+    }
+    ```
+  method: POST
 /api/v1/ui/dialog:
   desc: Displays a dialog window with a specified message and title.
   curl: |-

--- a/docs/_api_macroses/controllers/ru/GameController.ru.yml
+++ b/docs/_api_macroses/controllers/ru/GameController.ru.yml
@@ -128,36 +128,96 @@ desc: Этот контроллер обрабатывает общие игро
     }
     ```
   method: GET
-/api/v1/mods/info:
-  desc: Возвращает информацию об установленных модах.
+/api/v1/mods/get:
+  desc: Возвращает информацию об одном конкретном моде по его package_id или uid.
   curl: |-
-    **Example:**
+    **Пример:**
     ```bash
-    curl --request POST \
-    --url http://localhost:8765/api/v1/mods/info
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/get?uid=RedEyeDev.RIMAPI
     ```
   request: ''
   response: |-
-    **Response:**
+    **Ответ:**
+    ```json
+    {
+        "success": true,
+        "data": {
+            "name": "RIMAPI",
+            "package_id": "RedEyeDev.RIMAPI",
+            "load_order": 3,
+            "author": "RedEyeDev",
+            "description": "...",
+            "url": "...",
+            "version": "1.9.0",
+            "supported_versions": ["1.5", "1.6"],
+            "root_dir": "..."
+        },
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
+/api/v1/mods/info:
+  desc: Возвращает информацию об установленных модах. Можно отфильтровать по package_id, чтобы получить подробную информацию об одном моде.
+  curl: |-
+    **Пример (Все моды):**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/info
+    ```
+    **Пример (Один мод):**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/info?package_id=RedEyeDev.RIMAPI
+    ```
+  request: ''
+  response: |-
+    **Ответ:**
     ```json
     {
         "success": true,
         "data": [
             {
-            "name": "Core",
-            "package_id": "ludeon.rimworld",
-            "load_order": 0
-            },
-            {
-            "name": "Royalty",
-            "package_id": "ludeon.rimworld.royalty",
-            "load_order": 1
-            },
-            {
-            "name": "Ideology",
-            "package_id": "ludeon.rimworld.ideology",
-            "load_order": 2
-            },
+            "name": "RIMAPI",
+            "package_id": "RedEyeDev.RIMAPI",
+            "load_order": 3,
+            "author": "RedEyeDev",
+            "description": "RIMAPI is a mod...",
+            "url": "https://...",
+            "version": "1.9.0",
+            "supported_versions": ["1.5", "1.6"],
+            "root_dir": "..."
+            }
+        ],
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
+/api/v1/mods/preview:
+  desc: Возвращает превью-изображение мода в виде строки, закодированной в base64.
+  curl: |-
+    **Пример:**
+    ```bash
+    curl --request GET \
+    --url http://localhost:8765/api/v1/mods/preview?package_id=RedEyeDev.RIMAPI
+    ```
+  request: ''
+  response: |-
+    **Ответ:**
+    ```json
+    {
+        "success": true,
+        "data": "iVBORw0KGgoAAAANSUhEUgAA...",
+        "errors": [],
+        "warnings": [],
+        "timestamp": "..."
+    }
+    ```
+  method: GET
             {
             "name": "Biotech",
             "package_id": "ludeon.rimworld.biotech",

--- a/tests/bruno_api_collection/Camera/Follow Pawn.yml
+++ b/tests/bruno_api_collection/Camera/Follow Pawn.yml
@@ -1,0 +1,19 @@
+info:
+  name: Follow Pawn
+  type: http
+  seq: 7
+
+http:
+  method: POST
+  url: "{{baseURL}}/api/v1/camera/follow/pawn?pawn_id=526"
+  params:
+    - name: pawn_id
+      value: "526"
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Game/All Defs.yml
+++ b/tests/bruno_api_collection/Game/All Defs.yml
@@ -1,7 +1,7 @@
 info:
   name: " All Defs"
   type: http
-  seq: 11
+  seq: 9
 
 http:
   method: GET

--- a/tests/bruno_api_collection/Game/Configure.yml
+++ b/tests/bruno_api_collection/Game/Configure.yml
@@ -1,16 +1,12 @@
 info:
   name: Configure
   type: http
-  seq: 7
+  seq: 5
 
 http:
   method: POST
   url: "{{baseURL}}/api/v1/mods/configure"
   auth: inherit
-
-body:
-  json: |-
-    {"package_ids":["brrainz.harmony","ludeon.rimworld","ludeon.rimworld.royalty","ludeon.rimworld.ideology","ludeon.rimworld.biotech","ludeon.rimworld.anomaly","ludeon.rimworld.odyssey","unlimitedhugs.hugslib","redeyedev.rimapi"],"restart_game":true}
 
 settings:
   encodeUrl: true

--- a/tests/bruno_api_collection/Game/Datetime.yml
+++ b/tests/bruno_api_collection/Game/Datetime.yml
@@ -1,7 +1,7 @@
 info:
   name: Datetime
   type: http
-  seq: 12
+  seq: 10
 
 http:
   method: GET

--- a/tests/bruno_api_collection/Game/Deselect.yml
+++ b/tests/bruno_api_collection/Game/Deselect.yml
@@ -1,7 +1,7 @@
 info:
   name: Deselect
   type: http
-  seq: 9
+  seq: 7
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Letter.yml
+++ b/tests/bruno_api_collection/Game/Letter.yml
@@ -1,7 +1,7 @@
 info:
   name: Letter
   type: http
-  seq: 15
+  seq: 13
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Load.yml
+++ b/tests/bruno_api_collection/Game/Load.yml
@@ -1,7 +1,7 @@
 info:
   name: Load
   type: http
-  seq: 17
+  seq: 15
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Menu.yml
+++ b/tests/bruno_api_collection/Game/Menu.yml
@@ -1,7 +1,7 @@
 info:
   name: Menu
   type: http
-  seq: 20
+  seq: 18
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Mod Preview.yml
+++ b/tests/bruno_api_collection/Game/Mod Preview.yml
@@ -1,0 +1,13 @@
+info:
+  name: Mod Preview
+  type: http
+  seq: 7
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/mods/preview?package_id=RedEyeDev.RIMAPI
+  body: none
+  auth: inherit
+
+query:
+  package_id: RedEyeDev.RIMAPI

--- a/tests/bruno_api_collection/Game/Mods/Mod Preview.yml
+++ b/tests/bruno_api_collection/Game/Mods/Mod Preview.yml
@@ -1,0 +1,19 @@
+info:
+  name: Mod Preview
+  type: http
+  seq: 3
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/mods/preview?uid=brrainz.harmony"
+  params:
+    - name: uid
+      value: brrainz.harmony
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Game/Mods/Mods Info.yml
+++ b/tests/bruno_api_collection/Game/Mods/Mods Info.yml
@@ -1,0 +1,19 @@
+info:
+  name: Mods Info
+  type: http
+  seq: 6
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/mods/info?uid=brrainz.harmony"
+  params:
+    - name: uid
+      value: brrainz.harmony
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/Game/Mods/Mods List.yml
+++ b/tests/bruno_api_collection/Game/Mods/Mods List.yml
@@ -1,11 +1,11 @@
 info:
-  name: Mods Info
+  name: Mods List
   type: http
-  seq: 6
+  seq: 2
 
 http:
   method: GET
-  url: "{{baseURL}}/api/v1/mods/info"
+  url: "{{baseURL}}/api/v1/mods/list"
   auth: inherit
 
 settings:

--- a/tests/bruno_api_collection/Game/Mods/folder.yml
+++ b/tests/bruno_api_collection/Game/Mods/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: Mods
+  type: folder
+  seq: 21
+
+request:
+  auth: inherit

--- a/tests/bruno_api_collection/Game/Open Tab.yml
+++ b/tests/bruno_api_collection/Game/Open Tab.yml
@@ -1,7 +1,7 @@
 info:
   name: Open Tab
   type: http
-  seq: 10
+  seq: 8
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Quit.yml
+++ b/tests/bruno_api_collection/Game/Quit.yml
@@ -1,7 +1,7 @@
 info:
   name: Quit
   type: http
-  seq: 21
+  seq: 20
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Run In Background Option.yml
+++ b/tests/bruno_api_collection/Game/Run In Background Option.yml
@@ -1,7 +1,7 @@
 info:
   name: Run In Background Option
   type: http
-  seq: 4
+  seq: 3
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Save.yml
+++ b/tests/bruno_api_collection/Game/Save.yml
@@ -1,7 +1,7 @@
 info:
   name: Save
   type: http
-  seq: 16
+  seq: 14
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Select Pawn.yml
+++ b/tests/bruno_api_collection/Game/Select Pawn.yml
@@ -1,7 +1,7 @@
 info:
   name: Select Pawn
   type: http
-  seq: 8
+  seq: 6
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Select-area.yml
+++ b/tests/bruno_api_collection/Game/Select-area.yml
@@ -1,19 +1,12 @@
 info:
   name: Select-area
   type: http
-  seq: 14
+  seq: 12
 
 http:
   method: POST
   url: "{{baseURL}}/api/v1/game/select-area"
   auth: inherit
-
-body:
-  json: |-
-    {
-            "position_a": { "x": 10, "y": 0, "z": 10 },
-            "position_b": { "x": 20, "y": 0, "z": 20 }
-        }
 
 settings:
   encodeUrl: true

--- a/tests/bruno_api_collection/Game/Settings.yml
+++ b/tests/bruno_api_collection/Game/Settings.yml
@@ -1,7 +1,7 @@
 info:
   name: Settings
   type: http
-  seq: 20
+  seq: 19
 
 http:
   method: GET

--- a/tests/bruno_api_collection/Game/Start DevQuick Game.yml
+++ b/tests/bruno_api_collection/Game/Start DevQuick Game.yml
@@ -1,7 +1,7 @@
 info:
   name: Start DevQuick Game
   type: http
-  seq: 18
+  seq: 16
 
 http:
   method: POST

--- a/tests/bruno_api_collection/Game/Start.yml
+++ b/tests/bruno_api_collection/Game/Start.yml
@@ -1,29 +1,12 @@
 info:
   name: Start
   type: http
-  seq: 19
+  seq: 17
 
 http:
   method: POST
   url: "{{baseURL}}/api/v1/game/start"
   auth: inherit
-
-body:
-  json: |-
-    {
-            "storyteller_name": "Randy",
-            "difficulty_name": "Peaceful",
-            "map_size": 120,
-            "permadeath": false,
-            "planet_coverage": 0.1,
-            "world_seed": "rickroll",
-            "starting_tile": "7298",
-            "starting_season": "2",
-            "overall_rainfall": 2,
-            "overall_temperature": 2,
-            "overall_population": 2,
-            "landmark_density": 2
-        }
 
 settings:
   encodeUrl: true

--- a/tests/bruno_api_collection/Game/Tile.yml
+++ b/tests/bruno_api_collection/Game/Tile.yml
@@ -1,7 +1,7 @@
 info:
   name: Tile
   type: http
-  seq: 13
+  seq: 11
 
 http:
   method: GET

--- a/tests/bruno_api_collection/Game/Version.yml
+++ b/tests/bruno_api_collection/Game/Version.yml
@@ -1,7 +1,7 @@
 info:
   name: Version
   type: http
-  seq: 5
+  seq: 4
 
 http:
   method: GET

--- a/tests/bruno_api_collection/Map/Create Growing Zone.yml
+++ b/tests/bruno_api_collection/Map/Create Growing Zone.yml
@@ -10,13 +10,10 @@ http:
     type: json
     data: |-
       {
-        "MapId": 0,
-        "PlantDef": "PlantCorn",
-        "Cells": [
-          {"X": 10, "Z": 20},
-          {"X": 11, "Z": 20},
-          {"X": 12, "Z": 20}
-        ]
+        "map_id": 0,
+        "plant_def": "Plant_Corn",
+        "point_a": {"x": 50, "y": 0, "z": 50},
+        "point_b": {"x": 54, "y": 0, "z": 54}
       }
   auth: inherit
 

--- a/tests/bruno_api_collection/UI/Window Close.yml
+++ b/tests/bruno_api_collection/UI/Window Close.yml
@@ -1,0 +1,22 @@
+info:
+  name: Window Close
+  type: http
+  seq: 3
+
+http:
+  method: POST
+  url: "{{baseURL}}/api/v1/ui/window/close"
+  auth: inherit
+  body:
+    mode: json
+    json: |-
+      {
+        "window_types": ["Dialog_NamePlayerSettlement"],
+        "force_pause_only": false
+      }
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/tests/bruno_api_collection/UI/Windows List.yml
+++ b/tests/bruno_api_collection/UI/Windows List.yml
@@ -1,0 +1,15 @@
+info:
+  name: Windows List
+  type: http
+  seq: 2
+
+http:
+  method: GET
+  url: "{{baseURL}}/api/v1/ui/windows"
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5


### PR DESCRIPTION
## Cleanup, docs, and Bruno housekeeping

Miscellaneous fixes and additions accumulated alongside the mod-endpoints
work — no behaviour changes to existing API endpoints.

### Changes

**Settings UI**
- Version label in the mod settings window now shows the git commit hash
  alongside the version number (e.g. `1.9.0 (a1b2c3d)`). The hash is
  embedded at build time via `AssemblyInformationalVersion`; falls back
  gracefully to the plain version string when built outside of git.

**Bruno configs**
- Fixed `Map / Create Growing Zone` — corrected to `snake_case` keys,
  `point_a` / `point_b` rectangle body, and valid `Plant_Corn` defName
- Added `Camera / Follow Pawn` — `POST /api/v1/camera/follow/pawn`
- Added `UI / Windows List` — `GET /api/v1/ui/windows`
- Added `UI / Window Close` — `POST /api/v1/ui/window/close`

**Docs**
- `CameraController.yml` — added entry for `/api/v1/camera/follow/pawn`
- `WindowController.yml` — added entries for `/api/v1/ui/windows` and
  `/api/v1/ui/window/close`

**Metadata**
- `README.md` — updated API version string
- `About/About.xml` — added `LoadAfter` section
- `CLAUDE.md` — added project guide for AI agents
